### PR TITLE
Reorder arguments in ServerClient.apply_environment

### DIFF
--- a/faculty/clients/server.py
+++ b/faculty/clients/server.py
@@ -206,7 +206,7 @@ class ServerClient(BaseClient):
         params = {"name": name} if name is not None else None
         return self._get(endpoint, ServerSchema(many=True), params=params)
 
-    def apply_environment(self, environment_id, server_id):
+    def apply_environment(self, server_id, environment_id):
         endpoint = "/instance/{}/environment/{}".format(
             server_id, environment_id
         )

--- a/tests/clients/test_server.py
+++ b/tests/clients/test_server.py
@@ -347,7 +347,7 @@ def test_server_client_apply_environment(mocker):
     mocker.patch.object(ServerClient, "_put_raw")
     client = ServerClient(mocker.Mock())
 
-    client.apply_environment(ENVIRONMENT_ID, SERVER_ID)
+    client.apply_environment(SERVER_ID, ENVIRONMENT_ID)
 
     ServerClient._put_raw.assert_called_once_with(
         "/instance/{}/environment/{}".format(SERVER_ID, ENVIRONMENT_ID)


### PR DESCRIPTION
PR #66 added ServerClient.apply_environment with the arguments (environment_id, server_id), however we usually put ids in the order (project, server, others). In this specific case, the server ID
seems more 'primary' as the server is the main resource from the point of view of the client.

This method does appear to yet be used by the CLI so I propose merging this PR before https://github.com/facultyai/faculty-cli/pull/11/ is merged.