### PR TITLE
Update copyright for company name change

### DIFF
--- a/faculty/__init__.py
+++ b/faculty/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/__init__.py
+++ b/faculty/clients/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/account.py
+++ b/faculty/clients/account.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/auth.py
+++ b/faculty/clients/auth.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/base.py
+++ b/faculty/clients/base.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/cluster.py
+++ b/faculty/clients/cluster.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/environment.py
+++ b/faculty/clients/environment.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/job.py
+++ b/faculty/clients/job.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/log.py
+++ b/faculty/clients/log.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/project.py
+++ b/faculty/clients/project.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/report.py
+++ b/faculty/clients/report.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/secret.py
+++ b/faculty/clients/secret.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/server.py
+++ b/faculty/clients/server.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/user.py
+++ b/faculty/clients/user.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/clients/workspace.py
+++ b/faculty/clients/workspace.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/datasets/__init__.py
+++ b/faculty/datasets/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/datasets/path.py
+++ b/faculty/datasets/path.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/datasets/session.py
+++ b/faculty/datasets/session.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/session/__init__.py
+++ b/faculty/session/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/faculty/session/accesstoken.py
+++ b/faculty/session/accesstoken.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     name="faculty",
     description="Python library for interacting with the Faculty platform.",
     url="https://sherlockml.com",
-    author="ASI Data Science",
+    author="Faculty",
     author_email="opensource@asidatascience.com",
     license="Apache Software License",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     description="Python library for interacting with the Faculty platform.",
     url="https://sherlockml.com",
     author="Faculty",
-     author_email="opensource@faculty.ai",
+    author_email="opensource@faculty.ai",
     license="Apache Software License",
     packages=find_packages(),
     use_scm_version={"version_scheme": "post-release"},

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     description="Python library for interacting with the Faculty platform.",
     url="https://sherlockml.com",
     author="Faculty",
-    author_email="opensource@asidatascience.com",
+     author_email="opensource@faculty.ai",
     license="Apache Software License",
     packages=find_packages(),
     use_scm_version={"version_scheme": "post-release"},

--- a/tests/clients/test_account.py
+++ b/tests/clients/test_account.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_auth.py
+++ b/tests/clients/test_auth.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_cluster.py
+++ b/tests/clients/test_cluster.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_environment.py
+++ b/tests/clients/test_environment.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_init.py
+++ b/tests/clients/test_init.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_job.py
+++ b/tests/clients/test_job.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_log.py
+++ b/tests/clients/test_log.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_project.py
+++ b/tests/clients/test_project.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_report.py
+++ b/tests/clients/test_report.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_secret.py
+++ b/tests/clients/test_secret.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_server.py
+++ b/tests/clients/test_server.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_user.py
+++ b/tests/clients/test_user.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/clients/test_workspace.py
+++ b/tests/clients/test_workspace.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/datasets/conftest.py
+++ b/tests/datasets/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/datasets/fixtures.py
+++ b/tests/datasets/fixtures.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/datasets/test_paths.py
+++ b/tests/datasets/test_paths.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/session/test_accesstoken.py
+++ b/tests/session/test_accesstoken.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/session/test_init.py
+++ b/tests/session/test_init.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 ASI Data Science
+# Copyright 2018-2019 Faculty Science Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
ASI Data Science (formally "Advanced Skills Initiative Limited", UK company number 08873131) has been renamed "Faculty Science Limited" as of 4th February 2019.