### PR TITLE
Update README for new URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 faculty
 =======
 
-.. image:: https://travis-ci.org/ASIDataScience/faculty.svg?branch=master
-    :target: https://travis-ci.org/ASIDataScience/faculty
+.. image:: https://travis-ci.org/facultyai/faculty.svg?branch=master
+    :target: https://travis-ci.org/facultyai/faculty
 
-A Python library for interacting with `the Faculty platform <https://sherlockml.com/>`_.
+A Python library for interacting with `the Faculty platform <https://faculty.ai/products-services/platform/>`_.


### PR DESCRIPTION
The Travis badge is broken because of the organisation name change. This fixes it.

It also changes the link in the README to point to the platform page on the website.

On this branch:

<img width="1012" alt="screenshot 2019-02-08 at 10 18 01" src="https://user-images.githubusercontent.com/1392879/52472284-d923e400-2b8a-11e9-9679-9bd92560fe98.png">
