### PR TITLE
Disable `ValidationError` on unknown keys

### DIFF
--- a/faculty/clients/account.py
+++ b/faculty/clients/account.py
@@ -15,15 +15,15 @@
 
 from collections import namedtuple
 
-from marshmallow import Schema, fields, post_load
+from marshmallow import fields, post_load
 
-from faculty.clients.base import BaseClient
+from faculty.clients.base import BaseSchema, BaseClient
 
 
 Account = namedtuple("Account", ["user_id"])
 
 
-class AccountSchema(Schema):
+class AccountSchema(BaseSchema):
     user_id = fields.UUID(data_key="userId", required=True)
 
     @post_load
@@ -34,7 +34,7 @@ class AccountSchema(Schema):
 AuthenticationResponse = namedtuple("AuthenticationResponse", ["account"])
 
 
-class AuthenticationResponseSchema(Schema):
+class AuthenticationResponseSchema(BaseSchema):
     account = fields.Nested(AccountSchema, required=True)
 
     @post_load

--- a/faculty/clients/base.py
+++ b/faculty/clients/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import requests
-from marshmallow import Schema, fields, ValidationError
+from marshmallow import Schema, fields, ValidationError, EXCLUDE
 
 from faculty.clients.auth import FacultyAuth
 
@@ -82,7 +82,12 @@ HTTP_ERRORS = {
 }
 
 
-class ErrorSchema(Schema):
+class BaseSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+
+class ErrorSchema(BaseSchema):
     error = fields.String(required=True)
 
 

--- a/faculty/clients/cluster.py
+++ b/faculty/clients/cluster.py
@@ -15,9 +15,9 @@
 
 from collections import namedtuple
 
-from marshmallow import Schema, fields, post_load
+from marshmallow import fields, post_load
 
-from faculty.clients.base import BaseClient
+from faculty.clients.base import BaseSchema, BaseClient
 
 
 NodeType = namedtuple(
@@ -37,7 +37,7 @@ NodeType = namedtuple(
 )
 
 
-class NodeTypeSchema(Schema):
+class NodeTypeSchema(BaseSchema):
 
     id = fields.String(data_key="nodeTypeId", required=True)
     name = fields.String(missing=None)

--- a/faculty/clients/environment.py
+++ b/faculty/clients/environment.py
@@ -15,9 +15,9 @@
 
 from collections import namedtuple
 
-from marshmallow import Schema, fields, post_load
+from marshmallow import fields, post_load
 
-from faculty.clients.base import BaseClient
+from faculty.clients.base import BaseSchema, BaseClient
 
 
 Environment = namedtuple(
@@ -34,7 +34,7 @@ Environment = namedtuple(
 )
 
 
-class EnvironmentSchema(Schema):
+class EnvironmentSchema(BaseSchema):
     id = fields.UUID(data_key="environmentId", required=True)
     project_id = fields.UUID(data_key="projectId", required=True)
     name = fields.String(required=True)

--- a/faculty/clients/job.py
+++ b/faculty/clients/job.py
@@ -15,10 +15,10 @@
 from collections import namedtuple
 from enum import Enum
 
-from marshmallow import Schema, fields, post_load
+from marshmallow import fields, post_load
 from marshmallow_enum import EnumField
 
-from faculty.clients.base import BaseClient
+from faculty.clients.base import BaseSchema, BaseClient
 
 
 class EnvironmentStepExecutionState(Enum):
@@ -100,7 +100,7 @@ Pagination = namedtuple("Pagination", ["start", "size", "previous", "next"])
 ListRunsResponse = namedtuple("ListRunsResponse", ["runs", "pagination"])
 
 
-class JobMetadataSchema(Schema):
+class JobMetadataSchema(BaseSchema):
     name = fields.String(required=True)
     description = fields.String(required=True)
 
@@ -109,7 +109,7 @@ class JobMetadataSchema(Schema):
         return JobMetadata(**data)
 
 
-class JobSummarySchema(Schema):
+class JobSummarySchema(BaseSchema):
     id = fields.UUID(data_key="jobId", required=True)
     metadata = fields.Nested(JobMetadataSchema, data_key="meta", required=True)
 
@@ -118,7 +118,7 @@ class JobSummarySchema(Schema):
         return JobSummary(**data)
 
 
-class EnvironmentStepExecutionSchema(Schema):
+class EnvironmentStepExecutionSchema(BaseSchema):
     environment_id = fields.UUID(data_key="environmentId", required=True)
     environment_step_id = fields.UUID(
         data_key="environmentStepId", required=True
@@ -137,7 +137,7 @@ class EnvironmentStepExecutionSchema(Schema):
         return EnvironmentStepExecution(**data)
 
 
-class SubrunSummarySchema(Schema):
+class SubrunSummarySchema(BaseSchema):
     id = fields.UUID(data_key="subrunId", required=True)
     subrun_number = fields.Integer(data_key="subrunNumber", required=True)
     state = EnumField(SubrunState, by_value=True, required=True)
@@ -149,7 +149,7 @@ class SubrunSummarySchema(Schema):
         return SubrunSummary(**data)
 
 
-class SubrunSchema(Schema):
+class SubrunSchema(BaseSchema):
     id = fields.UUID(data_key="subrunId", required=True)
     subrun_number = fields.Integer(data_key="subrunNumber", required=True)
     state = EnumField(SubrunState, by_value=True, required=True)
@@ -167,7 +167,7 @@ class SubrunSchema(Schema):
         return Subrun(**data)
 
 
-class RunSummarySchema(Schema):
+class RunSummarySchema(BaseSchema):
     id = fields.UUID(data_key="runId", required=True)
     run_number = fields.Integer(data_key="runNumber", required=True)
     state = EnumField(RunState, by_value=True, required=True)
@@ -180,7 +180,7 @@ class RunSummarySchema(Schema):
         return RunSummary(**data)
 
 
-class RunSchema(Schema):
+class RunSchema(BaseSchema):
     id = fields.UUID(data_key="runId", required=True)
     run_number = fields.Integer(data_key="runNumber", required=True)
     state = EnumField(RunState, by_value=True, required=True)
@@ -194,7 +194,7 @@ class RunSchema(Schema):
         return Run(**data)
 
 
-class RunIdSchema(Schema):
+class RunIdSchema(BaseSchema):
     runId = fields.UUID(required=True)
 
     @post_load
@@ -202,7 +202,7 @@ class RunIdSchema(Schema):
         return data["runId"]
 
 
-class PageSchema(Schema):
+class PageSchema(BaseSchema):
     start = fields.Integer(required=True)
     limit = fields.Integer(required=True)
 
@@ -211,7 +211,7 @@ class PageSchema(Schema):
         return Page(**data)
 
 
-class PaginationSchema(Schema):
+class PaginationSchema(BaseSchema):
     start = fields.Integer(required=True)
     size = fields.Integer(required=True)
     previous = fields.Nested(PageSchema, missing=None)
@@ -222,7 +222,7 @@ class PaginationSchema(Schema):
         return Pagination(**data)
 
 
-class ListRunsResponseSchema(Schema):
+class ListRunsResponseSchema(BaseSchema):
     pagination = fields.Nested(PaginationSchema, required=True)
     runs = fields.Nested(RunSummarySchema, many=True, required=True)
 

--- a/faculty/clients/log.py
+++ b/faculty/clients/log.py
@@ -14,9 +14,9 @@
 
 from collections import namedtuple
 
-from marshmallow import Schema, fields, post_load
+from marshmallow import fields, post_load
 
-from faculty.clients.base import BaseClient
+from faculty.clients.base import BaseSchema, BaseClient
 
 
 LogPart = namedtuple(
@@ -25,7 +25,7 @@ LogPart = namedtuple(
 LogPartsResponse = namedtuple("LogPartsResponse", ["log_parts"])
 
 
-class LogPartSchema(Schema):
+class LogPartSchema(BaseSchema):
     log_part_number = fields.Integer(data_key="logPartNumber", required=True)
     line_number = fields.Integer(data_key="lineNumber", required=True)
     content = fields.String(required=True)
@@ -36,7 +36,7 @@ class LogPartSchema(Schema):
         return LogPart(**data)
 
 
-class LogPartsResponseSchema(Schema):
+class LogPartsResponseSchema(BaseSchema):
     log_parts = fields.Nested(
         LogPartSchema, data_key="logParts", many=True, required=True
     )

--- a/faculty/clients/project.py
+++ b/faculty/clients/project.py
@@ -15,15 +15,15 @@
 
 from collections import namedtuple
 
-from marshmallow import Schema, fields, post_load
+from marshmallow import fields, post_load
 
-from faculty.clients.base import BaseClient
+from faculty.clients.base import BaseSchema, BaseClient
 
 
 Project = namedtuple("Project", ["id", "name", "owner_id"])
 
 
-class ProjectSchema(Schema):
+class ProjectSchema(BaseSchema):
 
     id = fields.UUID(data_key="projectId", required=True)
     name = fields.Str(required=True)

--- a/faculty/clients/report.py
+++ b/faculty/clients/report.py
@@ -14,9 +14,9 @@
 
 from collections import namedtuple
 
-from marshmallow import Schema, fields, post_load
+from marshmallow import fields, post_load
 
-from faculty.clients.base import BaseClient
+from faculty.clients.base import BaseSchema, BaseClient
 
 Report = namedtuple(
     "Report", ["created_at", "name", "id", "description", "active_version"]
@@ -48,7 +48,7 @@ ReportVersion = namedtuple(
 )
 
 
-class ReportVersionSchema(Schema):
+class ReportVersionSchema(BaseSchema):
     id = fields.UUID(data_key="version_id", required=True)
     created_at = fields.DateTime(required=True)
     author_id = fields.UUID(required=True)
@@ -62,7 +62,7 @@ class ReportVersionSchema(Schema):
         return ReportVersion(**data)
 
 
-class ReportSchema(Schema):
+class ReportSchema(BaseSchema):
     created_at = fields.DateTime(required=True)
     name = fields.String(required=True, data_key="report_name")
     id = fields.UUID(required=True, data_key="report_id")
@@ -74,7 +74,7 @@ class ReportSchema(Schema):
         return Report(**data)
 
 
-class ReportWithVersionsSchema(Schema):
+class ReportWithVersionsSchema(BaseSchema):
     created_at = fields.DateTime(required=True)
     name = fields.String(required=True, data_key="report_name")
     id = fields.UUID(required=True, data_key="report_id")

--- a/faculty/clients/secret.py
+++ b/faculty/clients/secret.py
@@ -14,16 +14,16 @@
 
 from collections import namedtuple
 
-from marshmallow import Schema, fields, post_load
+from marshmallow import fields, post_load
 
-from faculty.clients.base import BaseClient
+from faculty.clients.base import BaseSchema, BaseClient
 
 DatasetsSecrets = namedtuple(
     "DatasetsSecrets", ["bucket", "access_key", "secret_key", "verified"]
 )
 
 
-class DatasetsSecretsSchema(Schema):
+class DatasetsSecretsSchema(BaseSchema):
     bucket = fields.String(required=True)
     access_key = fields.String(required=True)
     secret_key = fields.String(required=True)

--- a/faculty/clients/server.py
+++ b/faculty/clients/server.py
@@ -16,16 +16,16 @@
 from collections import namedtuple
 from enum import Enum
 
-from marshmallow import Schema, fields, post_load, ValidationError
+from marshmallow import fields, post_load, ValidationError
 from marshmallow_enum import EnumField
 
-from faculty.clients.base import BaseClient
+from faculty.clients.base import BaseSchema, BaseClient
 
 
 ServerSize = namedtuple("ServerSize", ["milli_cpus", "memory_mb"])
 
 
-class ServerSizeSchema(Schema):
+class ServerSizeSchema(BaseSchema):
 
     milli_cpus = fields.Integer(data_key="milliCpus", required=True)
     memory_mb = fields.Integer(data_key="memoryMb", required=True)
@@ -45,7 +45,7 @@ class ServerStatus(Enum):
 Service = namedtuple("Service", ["name", "host", "port", "scheme", "uri"])
 
 
-class ServiceSchema(Schema):
+class ServiceSchema(BaseSchema):
 
     name = fields.String(required=True)
     host = fields.String(required=True)
@@ -80,7 +80,7 @@ Server = namedtuple(
 )
 
 
-class ServerSchema(Schema):
+class ServerSchema(BaseSchema):
 
     id = fields.UUID(data_key="instanceId", required=True)
     project_id = fields.UUID(data_key="projectId", required=True)
@@ -127,7 +127,7 @@ class ServerSchema(Schema):
         )
 
 
-class ServerIdSchema(Schema):
+class ServerIdSchema(BaseSchema):
 
     instanceId = fields.UUID(required=True)
 
@@ -139,7 +139,7 @@ class ServerIdSchema(Schema):
 SSHDetails = namedtuple("SSHDetails", ["hostname", "port", "username", "key"])
 
 
-class SSHDetailsSchema(Schema):
+class SSHDetailsSchema(BaseSchema):
 
     hostname = fields.String(required=True)
     port = fields.Integer(required=True)

--- a/faculty/clients/user.py
+++ b/faculty/clients/user.py
@@ -16,10 +16,10 @@
 from collections import namedtuple
 from enum import Enum
 
-from marshmallow import Schema, fields, post_load
+from marshmallow import fields, post_load
 from marshmallow_enum import EnumField
 
-from faculty.clients.base import BaseClient
+from faculty.clients.base import BaseSchema, BaseClient
 
 
 class GlobalRole(Enum):
@@ -43,7 +43,7 @@ User = namedtuple(
 )
 
 
-class UserSchema(Schema):
+class UserSchema(BaseSchema):
 
     id = fields.UUID(data_key="userId", required=True)
     username = fields.Str(required=True)

--- a/faculty/clients/workspace.py
+++ b/faculty/clients/workspace.py
@@ -15,16 +15,10 @@
 from enum import Enum
 from collections import namedtuple
 
-from marshmallow import (
-    Schema,
-    fields,
-    post_load,
-    validates_schema,
-    ValidationError,
-)
+from marshmallow import fields, post_load, validates_schema, ValidationError
 from marshmallow_enum import EnumField
 
-from faculty.clients.base import BaseClient
+from faculty.clients.base import BaseSchema, BaseClient
 
 
 class FileNodeType(Enum):
@@ -40,7 +34,7 @@ Directory = namedtuple(
 ListResponse = namedtuple("ListResponse", ["project_id", "path", "content"])
 
 
-class FileNodeSchema(Schema):
+class FileNodeSchema(BaseSchema):
 
     path = fields.String(required=True)
     name = fields.String(required=True)
@@ -69,7 +63,7 @@ class FileNodeSchema(Schema):
             raise ValueError("Invalid file node type.")
 
 
-class ListResponseSchema(Schema):
+class ListResponseSchema(BaseSchema):
 
     project_id = fields.UUID(data_key="project_id", required=True)
     path = fields.String(required=True)

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -101,6 +101,17 @@ class DummyClient(BaseClient):
     SERVICE_NAME = MOCK_SERVICE_NAME
 
 
+def test_base_schema_ignores_unknown_fields():
+    """Check that fields in the data but not in the schema do not error.
+
+    marshmallow version 3 changed the default behaviour of schemas to raise a
+    ValidationError if there are any fields in the data being deserialised
+    which are not configured in the schema. Our BaseSchema is configured to
+    disable this behaviour.
+    """
+    assert BaseSchema().load({"unknown": "field"}) == {}
+
+
 def test_get(requests_mock, session, patch_auth):
     requests_mock.get(
         MOCK_SERVICE_URL,

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -16,9 +16,10 @@
 from collections import namedtuple
 
 import pytest
-from marshmallow import Schema, fields, post_load
+from marshmallow import fields, post_load
 
 from faculty.clients.base import (
+    BaseSchema,
     BaseClient,
     InvalidResponse,
     HTTPError,
@@ -88,7 +89,7 @@ def patch_auth(mocker, session):
 DummyObject = namedtuple("DummyObject", ["foo"])
 
 
-class DummySchema(Schema):
+class DummySchema(BaseSchema):
     foo = fields.String(required=True)
 
     @post_load


### PR DESCRIPTION
marshmallow 3 changed its default behaviour so that if any fields are present in data being deserialised but are not in the schema, a `ValidationError` is raised.

This PR reintroduces a faculty `BaseSchema` with this behaviour disabled.

This PR addresses issue #71.