### PR TITLE
Add a method to list runs to the experiment client

### DIFF
--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -103,7 +103,6 @@ class PageSchema(BaseSchema):
         return Page(**data)
 
 
-# TODO reuse pagination from jobs?
 class PaginationSchema(BaseSchema):
     start = fields.Integer(required=True)
     size = fields.Integer(required=True)

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -55,6 +55,12 @@ ExperimentRun = namedtuple(
     ],
 )
 
+Page = namedtuple("Page", ["start", "limit"])
+Pagination = namedtuple("Pagination", ["start", "size", "previous", "next"])
+ListExperimentRunsResponse = namedtuple(
+    "ListExperimentRunsResponse", ["runs", "pagination"]
+)
+
 
 class ExperimentSchema(BaseSchema):
     id = fields.Integer(data_key="experimentId", required=True)
@@ -86,6 +92,36 @@ class ExperimentRunSchema(BaseSchema):
     @post_load
     def make_experiment_run(self, data):
         return ExperimentRun(**data)
+
+
+class PageSchema(BaseSchema):
+    start = fields.Integer(required=True)
+    limit = fields.Integer(required=True)
+
+    @post_load
+    def make_page(self, data):
+        return Page(**data)
+
+
+# TODO reuse pagination from jobs?
+class PaginationSchema(BaseSchema):
+    start = fields.Integer(required=True)
+    size = fields.Integer(required=True)
+    previous = fields.Nested(PageSchema, missing=None)
+    next = fields.Nested(PageSchema, missing=None)
+
+    @post_load
+    def make_pagination(self, data):
+        return Pagination(**data)
+
+
+class ListExperimentRunsResponseSchema(BaseSchema):
+    pagination = fields.Nested(PaginationSchema, required=True)
+    runs = fields.Nested(ExperimentRunSchema, many=True, required=True)
+
+    @post_load
+    def make_list_runs_response_schema(self, data):
+        return ListExperimentRunsResponse(**data)
 
 
 class CreateRunSchema(BaseSchema):
@@ -195,3 +231,65 @@ class ExperimentClient(BaseClient):
         """
         endpoint = "/project/{}/run/{}".format(project_id, run_id)
         return self._get(endpoint, ExperimentRunSchema())
+
+    def list_runs(
+        self,
+        project_id,
+        experiment_ids=None,
+        lifecycle_stage=None,
+        start=None,
+        limit=None,
+    ):
+        """List experiment runs.
+
+        This method returns pages of runs. If less than the full number of runs
+        for the job is returned, the ``next`` page of the returned response
+        object will not be ``None``:
+
+        >>> response = client.list_runs(project_id)
+        >>> response.pagination.next
+        Page(start=10, limit=10)
+
+        Get all experiment runs by making successive calls to ``list_runs``,
+        passing the ``start`` and ``limit`` of the ``next`` page each time
+        until ``next`` is returned as ``None``.
+
+        Parameters
+        ----------
+        project_id : uuid.UUID
+        experiment_ids : List[int], optional
+            To filter runs of experiments with the given IDs only. If an empty
+            list is passed, a result with an empty list of runs is returned.
+        start : int, optional
+            The (zero-indexed) starting point of runs to retrieve.
+        limit : int, optional
+            The maximum number of runs to retrieve.
+
+        Returns
+        -------
+        ListExperimentRunsResponse
+        """
+        if lifecycle_stage is not None:
+            raise NotImplementedError("lifecycle_stage is not supported.")
+
+        query_params = []
+        if experiment_ids is not None:
+            if len(experiment_ids) == 0:
+                return ListExperimentRunsResponse(
+                    runs=[],
+                    pagination=Pagination(
+                        start=0, size=0, previous=None, next=None
+                    ),
+                )
+            for experiment_id in experiment_ids:
+                query_params.append(("experimentId", experiment_id))
+
+        if start is not None:
+            query_params.append(("start", start))
+        if limit is not None:
+            query_params.append(("limit", limit))
+
+        endpoint = "/project/{}/run".format(project_id)
+        return self._get(
+            endpoint, ListExperimentRunsResponseSchema(), params=query_params
+        )

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -259,6 +259,7 @@ class ExperimentClient(BaseClient):
         experiment_ids : List[int], optional
             To filter runs of experiments with the given IDs only. If an empty
             list is passed, a result with an empty list of runs is returned.
+            By default, runs from all experiments are returned.
         start : int, optional
             The (zero-indexed) starting point of runs to retrieve.
         limit : int, optional

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -28,6 +28,10 @@ from faculty.clients.experiment import (
     ExperimentRunSchema,
     ExperimentRunStatus,
     CreateRunSchema,
+    ListExperimentRunsResponse,
+    ListExperimentRunsResponseSchema,
+    Page,
+    Pagination,
 )
 
 
@@ -85,6 +89,30 @@ EXPERIMENT_RUN_BODY = {
     "startedAt": RUN_STARTED_AT_STRING_JAVA,
     "endedAt": RUN_ENDED_AT_STRING,
     "deletedAt": DELETED_AT_STRING,
+}
+
+PAGINATION = Pagination(
+    start=20,
+    size=10,
+    previous=Page(start=10, limit=10),
+    next=Page(start=30, limit=10),
+)
+PAGINATION_BODY = {
+    "start": PAGINATION.start,
+    "size": PAGINATION.size,
+    "previous": {
+        "start": PAGINATION.previous.start,
+        "limit": PAGINATION.previous.limit,
+    },
+    "next": {"start": PAGINATION.next.start, "limit": PAGINATION.next.limit},
+}
+
+LIST_EXPERIMENT_RUNS_RESPONSE = ListExperimentRunsResponse(
+    runs=[EXPERIMENT_RUN], pagination=PAGINATION
+)
+LIST_EXPERIMENT_RUNS_RESPONSE_BODY = {
+    "runs": [EXPERIMENT_RUN_BODY],
+    "pagination": PAGINATION_BODY,
 }
 
 
@@ -235,4 +263,83 @@ def test_experiment_client_get_run(mocker):
     ExperimentClient._get.assert_called_once_with(
         "/project/{}/run/{}".format(PROJECT_ID, EXPERIMENT_RUN_ID),
         schema_mock.return_value,
+    )
+
+
+def test_list_runs_schema(mocker):
+    data = ListExperimentRunsResponseSchema().load(
+        LIST_EXPERIMENT_RUNS_RESPONSE_BODY
+    )
+    assert data == LIST_EXPERIMENT_RUNS_RESPONSE
+
+
+# TODO test all edge cases of pagination or factor it out from jobs?
+
+
+def test_experiment_client_list_runs_all(mocker):
+    mocker.patch.object(
+        ExperimentClient, "_get", return_value=LIST_EXPERIMENT_RUNS_RESPONSE
+    )
+    schema_mock = mocker.patch(
+        "faculty.clients.experiment.ListExperimentRunsResponseSchema"
+    )
+
+    client = ExperimentClient(mocker.Mock())
+    list_result = client.list_runs(PROJECT_ID)
+    assert list_result == LIST_EXPERIMENT_RUNS_RESPONSE
+
+    schema_mock.assert_called_once_with()
+    ExperimentClient._get.assert_called_once_with(
+        "/project/{}/run".format(PROJECT_ID),
+        schema_mock.return_value,
+        params=[],
+    )
+
+
+def test_experiment_client_list_runs_experiments_filter(mocker):
+    mocker.patch.object(
+        ExperimentClient, "_get", return_value=LIST_EXPERIMENT_RUNS_RESPONSE
+    )
+    schema_mock = mocker.patch(
+        "faculty.clients.experiment.ListExperimentRunsResponseSchema"
+    )
+
+    client = ExperimentClient(mocker.Mock())
+    list_result = client.list_runs(PROJECT_ID, experiment_ids=[123, 456])
+    assert list_result == LIST_EXPERIMENT_RUNS_RESPONSE
+    schema_mock.assert_called_once_with()
+    ExperimentClient._get.assert_called_once_with(
+        "/project/{}/run".format(PROJECT_ID),
+        schema_mock.return_value,
+        params=[("experimentId", 123), ("experimentId", 456)],
+    )
+
+
+def test_experiment_client_list_runs_experiments_filter_empty(mocker):
+    client = ExperimentClient(mocker.Mock())
+    list_result = client.list_runs(PROJECT_ID, experiment_ids=[])
+
+    assert list_result == ListExperimentRunsResponse(
+        runs=[],
+        pagination=Pagination(start=0, size=0, previous=None, next=None),
+    )
+
+
+def test_experiment_client_list_runs_page(mocker):
+    mocker.patch.object(
+        ExperimentClient, "_get", return_value=LIST_EXPERIMENT_RUNS_RESPONSE
+    )
+    schema_mock = mocker.patch(
+        "faculty.clients.experiment.ListExperimentRunsResponseSchema"
+    )
+
+    client = ExperimentClient(mocker.Mock())
+    list_result = client.list_runs(PROJECT_ID, start=20, limit=10)
+    assert list_result == LIST_EXPERIMENT_RUNS_RESPONSE
+
+    schema_mock.assert_called_once_with()
+    ExperimentClient._get.assert_called_once_with(
+        "/project/{}/run".format(PROJECT_ID),
+        schema_mock.return_value,
+        params=[("start", 20), ("limit", 10)],
     )

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -31,7 +31,9 @@ from faculty.clients.experiment import (
     ListExperimentRunsResponse,
     ListExperimentRunsResponseSchema,
     Page,
+    PageSchema,
     Pagination,
+    PaginationSchema,
 )
 
 
@@ -90,6 +92,9 @@ EXPERIMENT_RUN_BODY = {
     "endedAt": RUN_ENDED_AT_STRING,
     "deletedAt": DELETED_AT_STRING,
 }
+
+PAGE = Page(start=3, limit=10)
+PAGE_BODY = {"start": PAGE.start, "limit": PAGE.limit}
 
 PAGINATION = Pagination(
     start=20,
@@ -273,7 +278,22 @@ def test_list_runs_schema(mocker):
     assert data == LIST_EXPERIMENT_RUNS_RESPONSE
 
 
-# TODO test all edge cases of pagination or factor it out from jobs?
+def test_page_schema():
+    data = PageSchema().load(PAGE_BODY)
+    assert data == PAGE
+
+
+def test_pagination_schema():
+    data = PaginationSchema().load(PAGINATION_BODY)
+    assert data == PAGINATION
+
+
+@pytest.mark.parametrize("field", ["previous", "next"])
+def test_pagination_schema_nullable_field(field):
+    body = PAGINATION_BODY.copy()
+    del body[field]
+    data = PaginationSchema().load(body)
+    assert getattr(data, field) is None
 
 
 def test_experiment_client_list_runs_all(mocker):


### PR DESCRIPTION
Please check if you agree with the following semantics of the `experiment_ids` filter:

- `None` -> runs of all experiments returned
- `[]` -> no runs returned

Filtering by `lifecycle_stage` will be added in next versions.

Pagination is done in the same way as job runs. As discussed, we might want to factor it out later.