### PR TITLE
Log Run data

### DIFF
--- a/faculty/clients/base.py
+++ b/faculty/clients/base.py
@@ -171,6 +171,13 @@ class BaseClient(object):
         response = self._put_raw(endpoint, **kwargs)
         return _deserialise_response(schema, response)
 
+    def _patch_raw(self, endpoint, *args, **kwargs):
+        return self._request("PATCH", endpoint, *args, **kwargs)
+
+    def _patch(self, endpoint, schema, **kwargs):
+        response = self._patch_raw(endpoint, **kwargs)
+        return _deserialise_response(schema, response)
+
     def _delete_raw(self, endpoint, *args, **kwargs):
         return self._request("DELETE", endpoint, *args, **kwargs)
 

--- a/faculty/clients/base.py
+++ b/faculty/clients/base.py
@@ -103,7 +103,7 @@ def _check_status(response):
             data = ErrorSchema().load(response.json())
         except (ValueError, ValidationError):
             data = {}
-        raise cls(response, data.get("error"), data.get("errorCode"))
+        raise cls(response, data.get("error"), data.get("error_code"))
 
 
 def _deserialise_response(schema, response):
@@ -145,7 +145,6 @@ class BaseClient(object):
         url = self.session.service_url(self.SERVICE_NAME, endpoint)
         response = self.http_session.request(method, url, *args, **kwargs)
         if check_status:
-            print(response)
             _check_status(response)
         return response
 

--- a/faculty/clients/base.py
+++ b/faculty/clients/base.py
@@ -93,7 +93,7 @@ class BaseSchema(Schema):
 
 class ErrorSchema(BaseSchema):
     error = fields.String(missing=None)
-    error_code = fields.String(data_key="error_code", missing=None)
+    error_code = fields.String(data_key="errorCode", missing=None)
 
 
 def _check_status(response):

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -353,7 +353,7 @@ class ExperimentClient(BaseClient):
         metrics : List[Metric], optional
             Each metric will be inserted.
         params : List[Param], optional
-            Each param will be inserted. Note that on a name conflict the 
+            Each param will be inserted. Note that on a name conflict the
             entire operation will be rejected.
         tags : List[Tag], optional
             Each tag be upserted.

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -100,13 +100,14 @@ class ExperimentRunSchema(BaseSchema):
         return ExperimentRun(**data)
 
 
-class ExperimentRunTagSchema(BaseSchema):
+class ExperimentRunMetricSchema(BaseSchema):
     key = fields.String(required=True)
-    value = fields.String(required=True)
+    value = fields.Float(required=True)
+    timestamp = fields.DateTime(missing=None)
 
     @post_load
-    def make_experiment_run_tag(self, data):
-        return ExperimentRunTag(**data)
+    def make_experiment_run_metric(self, data):
+        return ExperimentRunMetric(**data)
 
 
 class ExperimentRunParamSchema(BaseSchema):
@@ -118,14 +119,13 @@ class ExperimentRunParamSchema(BaseSchema):
         return ExperimentRunParam(**data)
 
 
-class ExperimentRunMetricSchema(BaseSchema):
+class ExperimentRunTagSchema(BaseSchema):
     key = fields.String(required=True)
-    value = fields.Float(required=True)
-    timestamp = fields.DateTime(missing=None)
+    value = fields.String(required=True)
 
     @post_load
-    def make_experiment_run_metric(self, data):
-        return ExperimentRunMetric(**data)
+    def make_experiment_run_tag(self, data):
+        return ExperimentRunTag(**data)
 
 
 class ExperimentRunDataSchema(BaseSchema):
@@ -343,12 +343,12 @@ class ExperimentClient(BaseClient):
         ----------
         project_id : uuid.UUID
         run_id : uuid.UUID
-        metrics : List[experiments.ExperimentRunMetric], optional
+        metrics : List[ExperimentRunMetric], optional
             Each metric will be inserted.
-        params : List[experiments.ExperimentRunMetric], optional
+        params : List[ExperimentRunMetric], optional
             Each param will be inserted and rejected if the given key is
             present.
-        tags : List[experiments.ExperimentRunTag], optional
+        tags : List[ExperimentRunTag], optional
             Each tag be upserted.
 
         Returns
@@ -357,10 +357,6 @@ class ExperimentClient(BaseClient):
         """
         endpoint = "/project/{}/run/{}/data".format(project_id, run_id)
         payload = ExperimentRunDataSchema().dump(
-            {
-                "metrics": ExperimentRunMetricSchema(many=True).dump(metrics),
-                "params": ExperimentRunParamSchema(many=True).dump(params),
-                "tags": ExperimentRunTagSchema(many=True).dump(tags),
-            }
+            {"metrics": metrics, "params": params, "tags": tags}
         )
         return self._patch_raw(endpoint, json=payload)

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -20,6 +20,7 @@ from marshmallow_enum import EnumField
 
 from faculty.clients.base import BaseClient, BaseSchema, Conflict
 
+
 class ParamConflictError(Exception):
     def __init__(self, response, message, conflicting_params=None):
         self.response = response
@@ -352,7 +353,7 @@ class ExperimentClient(BaseClient):
         run_id : uuid.UUID
         metrics : List[Metric], optional
             Each metric will be inserted.
-        params : List[Metric], optional
+        params : List[Param], optional
             Each param will be inserted and rejected if the given key is
             present.
         tags : List[Tag], optional
@@ -367,7 +368,7 @@ class ExperimentClient(BaseClient):
             {"metrics": metrics, "params": params, "tags": tags}
         )
         try:
-            return self._patch_raw(endpoint, json=payload)
+            self._patch_raw(endpoint, json=payload)
         except Conflict as err:
             if err.error_code == "conflicting_params":
                 raise ParamConflictError(
@@ -376,4 +377,4 @@ class ExperimentClient(BaseClient):
                     err.response.json()["parameterKeys"],
                 )
             else:
-                raise err
+                raise

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -55,11 +55,9 @@ ExperimentRun = namedtuple(
     ],
 )
 
-ExperimentRunMetric = namedtuple(
-    "ExperimentRunMetric", ["key", "value", "timestamp"]
-)
-ExperimentRunParam = namedtuple("ExperimentRunParam", ["key", "value"])
-ExperimentRunTag = namedtuple("ExperimentRunTag", ["key", "value"])
+Metric = namedtuple("Metric", ["key", "value", "timestamp"])
+Param = namedtuple("Param", ["key", "value"])
+Tag = namedtuple("Tag", ["key", "value"])
 
 Page = namedtuple("Page", ["start", "limit"])
 Pagination = namedtuple("Pagination", ["start", "size", "previous", "next"])
@@ -100,38 +98,38 @@ class ExperimentRunSchema(BaseSchema):
         return ExperimentRun(**data)
 
 
-class ExperimentRunMetricSchema(BaseSchema):
+class MetricSchema(BaseSchema):
     key = fields.String(required=True)
     value = fields.Float(required=True)
     timestamp = fields.DateTime(missing=None)
 
     @post_load
     def make_experiment_run_metric(self, data):
-        return ExperimentRunMetric(**data)
+        return Metric(**data)
 
 
-class ExperimentRunParamSchema(BaseSchema):
+class ParamSchema(BaseSchema):
     key = fields.String(required=True)
     value = fields.String(required=True)
 
     @post_load
     def make_experiment_run_param(self, data):
-        return ExperimentRunParam(**data)
+        return Param(**data)
 
 
-class ExperimentRunTagSchema(BaseSchema):
+class TagSchema(BaseSchema):
     key = fields.String(required=True)
     value = fields.String(required=True)
 
     @post_load
     def make_experiment_run_tag(self, data):
-        return ExperimentRunTag(**data)
+        return Tag(**data)
 
 
 class ExperimentRunDataSchema(BaseSchema):
-    metrics = fields.List(fields.Nested(ExperimentRunMetricSchema))
-    params = fields.List(fields.Nested(ExperimentRunParamSchema))
-    tags = fields.List(fields.Nested(ExperimentRunTagSchema))
+    metrics = fields.List(fields.Nested(MetricSchema))
+    params = fields.List(fields.Nested(ParamSchema))
+    tags = fields.List(fields.Nested(TagSchema))
 
 
 class PageSchema(BaseSchema):
@@ -343,12 +341,12 @@ class ExperimentClient(BaseClient):
         ----------
         project_id : uuid.UUID
         run_id : uuid.UUID
-        metrics : List[ExperimentRunMetric], optional
+        metrics : List[Metric], optional
             Each metric will be inserted.
-        params : List[ExperimentRunMetric], optional
+        params : List[Metric], optional
             Each param will be inserted and rejected if the given key is
             present.
-        tags : List[ExperimentRunTag], optional
+        tags : List[Tag], optional
             Each tag be upserted.
 
         Returns

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -353,8 +353,8 @@ class ExperimentClient(BaseClient):
         metrics : List[Metric], optional
             Each metric will be inserted.
         params : List[Param], optional
-            Each param will be inserted and rejected if the given key is
-            present.
+            Each param will be inserted. Note that on a name conflict the 
+            entire operation will be rejected.
         tags : List[Tag], optional
             Each tag be upserted.
 

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -362,6 +362,8 @@ class ExperimentClient(BaseClient):
         -------
         None
         """
+        if all([t is None for t in [metrics, params, tags]]):
+            return
         endpoint = "/project/{}/run/{}/data".format(project_id, run_id)
         payload = ExperimentRunDataSchema().dump(
             {"metrics": metrics, "params": params, "tags": tags}

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -23,7 +23,7 @@ from faculty.clients.base import BaseClient, BaseSchema, Conflict
 
 class ParamConflict(Exception):
     def __init__(self, message, conflicting_params=None):
-        self.message = message
+        super(ParamConflict, self).__init__(message)
         if conflicting_params is None:
             self.conflicting_params = []
         else:
@@ -110,10 +110,10 @@ class ExperimentRunSchema(BaseSchema):
 class MetricSchema(BaseSchema):
     key = fields.String(required=True)
     value = fields.Float(required=True)
-    timestamp = fields.DateTime(missing=None)
+    timestamp = fields.DateTime(required=True)
 
     @post_load
-    def make_experiment_run_metric(self, data):
+    def make_metric(self, data):
         return Metric(**data)
 
 
@@ -122,7 +122,7 @@ class ParamSchema(BaseSchema):
     value = fields.String(required=True)
 
     @post_load
-    def make_experiment_run_param(self, data):
+    def make_param(self, data):
         return Param(**data)
 
 
@@ -131,7 +131,7 @@ class TagSchema(BaseSchema):
     value = fields.String(required=True)
 
     @post_load
-    def make_experiment_run_tag(self, data):
+    def make_tag(self, data):
         return Tag(**data)
 
 

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -357,12 +357,8 @@ class ExperimentClient(BaseClient):
             entire operation will be rejected.
         tags : List[Tag], optional
             Each tag be upserted.
-
-        Returns
-        -------
-        None
         """
-        if all([t is None for t in [metrics, params, tags]]):
+        if all([kwarg is None for kwarg in [metrics, params, tags]]):
             return
         endpoint = "/project/{}/run/{}/data".format(project_id, run_id)
         payload = ExperimentRunDataSchema().dump(

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -21,9 +21,8 @@ from marshmallow_enum import EnumField
 from faculty.clients.base import BaseClient, BaseSchema, Conflict
 
 
-class ParamConflictError(Exception):
-    def __init__(self, response, message, conflicting_params=None):
-        self.response = response
+class ParamConflict(Exception):
+    def __init__(self, message, conflicting_params=None):
         self.message = message
         if conflicting_params is None:
             self.conflicting_params = []
@@ -371,10 +370,8 @@ class ExperimentClient(BaseClient):
             self._patch_raw(endpoint, json=payload)
         except Conflict as err:
             if err.error_code == "conflicting_params":
-                raise ParamConflictError(
-                    err.response,
-                    err.error,
-                    err.response.json()["parameterKeys"],
+                raise ParamConflict(
+                    err.error, err.response.json()["parameterKeys"]
                 )
             else:
                 raise

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -24,6 +24,7 @@ from faculty.clients.base import (
     BaseClient,
     BaseSchema,
     Conflict,
+    ErrorSchema,
     Forbidden,
     GatewayTimeout,
     HttpError,
@@ -57,6 +58,17 @@ BAD_RESPONSE_STATUSES = [
 ]
 
 HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
+
+
+def test_error_schema():
+    data = ErrorSchema().load({
+        "error": "error message",
+        "errorCode": "error code"
+    })
+    assert data == {
+        "error": "error message",
+        "error_code": "error code"
+    }
 
 
 @pytest.fixture

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -61,14 +61,10 @@ HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
 
 
 def test_error_schema():
-    data = ErrorSchema().load({
-        "error": "error message",
-        "errorCode": "error code"
-    })
-    assert data == {
-        "error": "error message",
-        "error_code": "error code"
-    }
+    data = ErrorSchema().load(
+        {"error": "error message", "errorCode": "error code"}
+    )
+    assert data == {"error": "error message", "error_code": "error code"}
 
 
 @pytest.fixture

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -16,6 +16,8 @@
 from collections import namedtuple
 
 import pytest
+from marshmallow import fields, post_load
+
 from faculty.clients.base import (
     BadGateway,
     BadRequest,
@@ -32,7 +34,6 @@ from faculty.clients.base import (
     ServiceUnavailable,
     Unauthorized,
 )
-from marshmallow import fields, post_load
 
 MOCK_SERVICE_NAME = "test-service"
 MOCK_ENDPOINT = "/endpoint"

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -56,7 +56,7 @@ BAD_RESPONSE_STATUSES = [
     (418, HttpError),
 ]
 
-HTTP_METHODS = ["GET", "POST", "PUT", "DELETE"]
+HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
 
 
 @pytest.fixture
@@ -149,6 +149,23 @@ def test_put(requests_mock, session, patch_auth):
 
     client = DummyClient(session)
     response = client._put(
+        MOCK_ENDPOINT, DummySchema(), json={"test": "payload"}
+    )
+
+    assert response == DummyObject(foo="bar")
+    assert mock.last_request.json() == {"test": "payload"}
+
+
+def test_patch(requests_mock, session, patch_auth):
+
+    mock = requests_mock.patch(
+        MOCK_SERVICE_URL,
+        request_headers=AUTHORIZATION_HEADER,
+        json={"foo": "bar"},
+    )
+
+    client = DummyClient(session)
+    response = client._patch(
         MOCK_ENDPOINT, DummySchema(), json={"test": "payload"}
     )
 

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -57,6 +57,7 @@ BAD_RESPONSE_STATUSES = [
 
 HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
 
+
 @pytest.fixture
 def session(mocker):
     session = mocker.Mock()

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -16,24 +16,23 @@
 from collections import namedtuple
 
 import pytest
-from marshmallow import fields, post_load
-
 from faculty.clients.base import (
-    BaseSchema,
-    BaseClient,
-    InvalidResponse,
-    HttpError,
-    BadRequest,
-    Unauthorized,
-    Forbidden,
-    NotFound,
-    MethodNotAllowed,
-    Conflict,
-    InternalServerError,
     BadGateway,
-    ServiceUnavailable,
+    BadRequest,
+    BaseClient,
+    BaseSchema,
+    Conflict,
+    Forbidden,
     GatewayTimeout,
+    HttpError,
+    InternalServerError,
+    InvalidResponse,
+    MethodNotAllowed,
+    NotFound,
+    ServiceUnavailable,
+    Unauthorized,
 )
+from marshmallow import fields, post_load
 
 MOCK_SERVICE_NAME = "test-service"
 MOCK_ENDPOINT = "/endpoint"
@@ -57,7 +56,6 @@ BAD_RESPONSE_STATUSES = [
 ]
 
 HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
-
 
 @pytest.fixture
 def session(mocker):

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -473,10 +473,8 @@ def test_log_run_data_param_conflict(mocker):
 
 
 def test_log_run_data_other_conflict(mocker):
-    expected_message = "conflict"
-    expected_error_code = "other-conflict"
     json_mock = mocker.Mock()
-    response_mock = Conflict(json_mock, expected_message, expected_error_code)
+    response_mock = Conflict(json_mock, "", "")
 
     mocker.patch.object(
         ExperimentClient, "_patch_raw", side_effect=response_mock
@@ -487,6 +485,6 @@ def test_log_run_data_other_conflict(mocker):
 
     client = ExperimentClient(mocker.Mock())
 
-    with pytest.raises(Conflict, match=expected_message):
+    with pytest.raises(Conflict):
         client.log_run_data(PROJECT_ID, EXPERIMENT_RUN_ID)
     run_data_schema_mock.assert_called_once_with()

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -102,11 +102,11 @@ EXPERIMENT_RUN_BODY = {
 TAG = Tag(key="tag-key", value="tag-value")
 TAG_BODY = {"key": "tag-key", "value": "tag-value"}
 
-OTHER_TAG = Tag(key="other-tag-key", value="tag-value")
-OTHER_TAG_BODY = {"key": "other-tag-key", "value": "tag-value"}
+OTHER_TAG = Tag(key="other-tag-key", value="other-tag-value")
+OTHER_TAG_BODY = {"key": "other-tag-key", "value": "other-tag-value"}
 
-PARAM = Param(key="parameter-key", value="tag-value")
-PARAM_BODY = {"key": "parameter-key", "value": "tag-value"}
+PARAM = Param(key="param-key", value="tag-value")
+PARAM_BODY = {"key": "param-key", "value": "tag-value"}
 
 METRIC_TIMESTAMP = datetime(2018, 3, 12, 16, 20, 22, 122000, tzinfo=UTC)
 METRIC_TIMESTAMP_STRING = "2018-03-12T16:20:22.122Z"

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -224,13 +224,13 @@ def test_experiment_run_data_schema():
 
 
 def test_experiment_run_data_schema_empty():
-    data = ExperimentRunDataSchema().load({})
+    data = ExperimentRunDataSchema().dump({})
     assert data == {}
 
 
 def test_experiment_run_data_schema_multiple():
-    data = ExperimentRunDataSchema().load({"tags": [TAG_BODY, OTHER_TAG_BODY]})
-    assert data == {"tags": [TAG, OTHER_TAG]}
+    data = ExperimentRunDataSchema().dump({"tags": [TAG, OTHER_TAG]})
+    assert data == {"tags": [TAG_BODY, OTHER_TAG_BODY]}
 
 
 @pytest.mark.parametrize("description", [None, "experiment description"])

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -458,9 +458,9 @@ def test_log_run_data(mocker):
 def test_log_run_data_param_conflict(mocker):
     message = "bad params"
     error_code = "conflicting_params"
-    json_mock = mocker.Mock()
-    json_mock.json.return_value = {"parameterKeys": ["bad-key"]}
-    exception = Conflict(json_mock, message, error_code)
+    response_mock = mocker.Mock()
+    response_mock.json.return_value = {"parameterKeys": ["bad-key"]}
+    exception = Conflict(response_mock, message, error_code)
 
     mocker.patch.object(ExperimentClient, "_patch_raw", side_effect=exception)
     run_data_schema_mock = mocker.patch(
@@ -475,8 +475,8 @@ def test_log_run_data_param_conflict(mocker):
 
 
 def test_log_run_data_other_conflict(mocker):
-    json_mock = mocker.Mock()
-    exception = Conflict(json_mock, "", "")
+    response_mock = mocker.Mock()
+    exception = Conflict(response_mock, "", "")
 
     mocker.patch.object(ExperimentClient, "_patch_raw", side_effect=exception)
     client = ExperimentClient(mocker.Mock())

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -105,16 +105,17 @@ TAG_BODY = {"key": "tag-key", "value": "tag-value"}
 OTHER_TAG = Tag(key="other-tag-key", value="other-tag-value")
 OTHER_TAG_BODY = {"key": "other-tag-key", "value": "other-tag-value"}
 
-PARAM = Param(key="param-key", value="tag-value")
-PARAM_BODY = {"key": "param-key", "value": "tag-value"}
+PARAM = Param(key="param-key", value="param-value")
+PARAM_BODY = {"key": "param-key", "value": "param-value"}
 
 METRIC_TIMESTAMP = datetime(2018, 3, 12, 16, 20, 22, 122000, tzinfo=UTC)
-METRIC_TIMESTAMP_STRING = "2018-03-12T16:20:22.122Z"
+METRIC_TIMESTAMP_STRING_JAVA = "2018-03-12T16:20:22.122Z"
+METRIC_TIMESTAMP_STRING_PYTHON = "2018-03-12T16:20:22.122000+00:00"
 METRIC = Metric(key="metric-key", value=123, timestamp=METRIC_TIMESTAMP)
 METRIC_BODY = {
     "key": "metric-key",
-    "value": 123,
-    "timestamp": METRIC_TIMESTAMP_STRING,
+    "value": 123.0,
+    "timestamp": METRIC_TIMESTAMP_STRING_PYTHON,
 }
 
 EXPERIMENT_RUN_DATA_BODY = {
@@ -216,8 +217,10 @@ def test_experiment_run_tag_schema():
 
 
 def test_experiment_run_data_schema():
-    data = ExperimentRunDataSchema().load(EXPERIMENT_RUN_DATA_BODY)
-    assert data == {"metrics": [METRIC], "params": [PARAM], "tags": [TAG]}
+    data = ExperimentRunDataSchema().dump(
+        {"metrics": [METRIC], "params": [PARAM], "tags": [TAG]}
+    )
+    assert data == EXPERIMENT_RUN_DATA_BODY
 
 
 def test_experiment_run_data_schema_empty():

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -463,15 +463,11 @@ def test_log_run_data_param_conflict(mocker):
     exception = Conflict(response_mock, message, error_code)
 
     mocker.patch.object(ExperimentClient, "_patch_raw", side_effect=exception)
-    run_data_schema_mock = mocker.patch(
-        "faculty.clients.experiment.ExperimentRunDataSchema"
-    )
 
     client = ExperimentClient(mocker.Mock())
 
     with pytest.raises(ParamConflict, match=message):
         client.log_run_data(PROJECT_ID, EXPERIMENT_RUN_ID, params=[PARAM])
-    run_data_schema_mock.assert_called_once_with()
 
 
 def test_log_run_data_other_conflict(mocker):

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -479,15 +479,10 @@ def test_log_run_data_other_conflict(mocker):
     exception = Conflict(json_mock, "", "")
 
     mocker.patch.object(ExperimentClient, "_patch_raw", side_effect=exception)
-    run_data_schema_mock = mocker.patch(
-        "faculty.clients.experiment.ExperimentRunDataSchema"
-    )
-
     client = ExperimentClient(mocker.Mock())
 
     with pytest.raises(Conflict):
         client.log_run_data(PROJECT_ID, EXPERIMENT_RUN_ID, params=[PARAM])
-    run_data_schema_mock.assert_called_once_with()
 
 
 def test_log_run_data_empty(mocker):

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -470,3 +470,23 @@ def test_log_run_data_param_conflict(mocker):
     with pytest.raises(ParamConflict, match=expected_message):
         client.log_run_data(PROJECT_ID, EXPERIMENT_RUN_ID)
     run_data_schema_mock.assert_called_once_with()
+
+
+def test_log_run_data_other_conflict(mocker):
+    expected_message = "conflict"
+    expected_error_code = "other-conflict"
+    json_mock = mocker.Mock()
+    response_mock = Conflict(json_mock, expected_message, expected_error_code)
+
+    mocker.patch.object(
+        ExperimentClient, "_patch_raw", side_effect=response_mock
+    )
+    run_data_schema_mock = mocker.patch(
+        "faculty.clients.experiment.ExperimentRunDataSchema"
+    )
+
+    client = ExperimentClient(mocker.Mock())
+
+    with pytest.raises(Conflict, match=expected_message):
+        client.log_run_data(PROJECT_ID, EXPERIMENT_RUN_ID)
+    run_data_schema_mock.assert_called_once_with()

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -25,12 +25,12 @@ from faculty.clients.experiment import (
     ExperimentSchema,
     ExperimentClient,
     ExperimentRun,
-    ExperimentRunMetric,
-    ExperimentRunMetricSchema,
-    ExperimentRunParam,
-    ExperimentRunParamSchema,
-    ExperimentRunTag,
-    ExperimentRunTagSchema,
+    Metric,
+    MetricSchema,
+    Param,
+    ParamSchema,
+    Tag,
+    TagSchema,
     ExperimentRunSchema,
     ExperimentRunStatus,
     CreateRunSchema,
@@ -97,22 +97,18 @@ EXPERIMENT_RUN_BODY = {
     "endedAt": RUN_ENDED_AT_STRING,
     "deletedAt": DELETED_AT_STRING,
 }
-EXPERIMENT_RUN_TAG = ExperimentRunTag(key="tag-key", value="tag-value")
+EXPERIMENT_RUN_TAG = Tag(key="tag-key", value="tag-value")
 EXPERIMENT_RUN_TAG_BODY = {"key": "tag-key", "value": "tag-value"}
 
-OTHER_EXPERIMENT_RUN_TAG = ExperimentRunTag(
-    key="other-tag-key", value="tag-value"
-)
+OTHER_EXPERIMENT_RUN_TAG = Tag(key="other-tag-key", value="tag-value")
 OTHER_EXPERIMENT_RUN_TAG_BODY = {"key": "other-tag-key", "value": "tag-value"}
 
-EXPERIMENT_RUN_PARAM = ExperimentRunParam(
-    key="parameter-key", value="tag-value"
-)
+EXPERIMENT_RUN_PARAM = Param(key="parameter-key", value="tag-value")
 EXPERIMENT_RUN_PARAM_BODY = {"key": "parameter-key", "value": "tag-value"}
 
 METRIC_TIMESTAMP = datetime(2018, 3, 12, 16, 20, 22, 122000, tzinfo=UTC)
 METRIC_TIMESTAMP_STRING = "2018-03-12T16:20:22.122Z"
-EXPERIMENT_RUN_METRIC = ExperimentRunMetric(
+EXPERIMENT_RUN_METRIC = Metric(
     key="metric-key", value=123, timestamp=METRIC_TIMESTAMP
 )
 EXPERIMENT_RUN_METRIC_BODY = {
@@ -205,17 +201,17 @@ def test_experiment_run_schema():
 
 
 def test_experiment_run_metric_schema():
-    data = ExperimentRunMetricSchema().load(EXPERIMENT_RUN_METRIC_BODY)
+    data = MetricSchema().load(EXPERIMENT_RUN_METRIC_BODY)
     assert data == EXPERIMENT_RUN_METRIC
 
 
 def test_experiment_run_param_schema():
-    data = ExperimentRunParamSchema().load(EXPERIMENT_RUN_PARAM_BODY)
+    data = ParamSchema().load(EXPERIMENT_RUN_PARAM_BODY)
     assert data == EXPERIMENT_RUN_PARAM
 
 
 def test_experiment_run_tag_schema():
-    data = ExperimentRunTagSchema().load(EXPERIMENT_RUN_TAG_BODY)
+    data = TagSchema().load(EXPERIMENT_RUN_TAG_BODY)
     assert data == EXPERIMENT_RUN_TAG
 
 

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -468,7 +468,7 @@ def test_log_run_data_param_conflict(mocker):
     client = ExperimentClient(mocker.Mock())
 
     with pytest.raises(ParamConflict, match=expected_message):
-        client.log_run_data(PROJECT_ID, EXPERIMENT_RUN_ID)
+        client.log_run_data(PROJECT_ID, EXPERIMENT_RUN_ID, params=[PARAM])
     run_data_schema_mock.assert_called_once_with()
 
 
@@ -486,5 +486,18 @@ def test_log_run_data_other_conflict(mocker):
     client = ExperimentClient(mocker.Mock())
 
     with pytest.raises(Conflict):
-        client.log_run_data(PROJECT_ID, EXPERIMENT_RUN_ID)
+        client.log_run_data(PROJECT_ID, EXPERIMENT_RUN_ID, params=[PARAM])
     run_data_schema_mock.assert_called_once_with()
+
+
+def test_log_run_data_empty(mocker):
+    mocker.patch.object(ExperimentClient, "_patch_raw")
+    run_data_schema_mock = mocker.patch(
+        "faculty.clients.experiment.ExperimentRunDataSchema"
+    )
+
+    client = ExperimentClient(mocker.Mock())
+
+    client.log_run_data(PROJECT_ID, EXPERIMENT_RUN_ID)
+    ExperimentClient._patch_raw.assert_not_called()
+    run_data_schema_mock.assert_not_called()

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -38,7 +38,7 @@ from faculty.clients.experiment import (
     Pagination,
     PaginationSchema,
     Param,
-    ParamConflictError,
+    ParamConflict,
     ParamSchema,
     Tag,
     TagSchema,
@@ -490,6 +490,6 @@ def test_log_run_data_param_conflict(mocker):
 
     client = ExperimentClient(mocker.Mock())
 
-    with pytest.raises(ParamConflictError, match=expected_message):
+    with pytest.raises(ParamConflict, match=expected_message):
         client.log_run_data(PROJECT_ID, EXPERIMENT_RUN_ID)
     run_data_schema_mock.assert_called_once_with()

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -110,7 +110,6 @@ EXPERIMENT_RUN_PARAM = ExperimentRunParam(
 )
 EXPERIMENT_RUN_PARAM_BODY = {"key": "parameter-key", "value": "tag-value"}
 
-
 METRIC_TIMESTAMP = datetime(2018, 3, 12, 16, 20, 22, 122000, tzinfo=UTC)
 METRIC_TIMESTAMP_STRING = "2018-03-12T16:20:22.122Z"
 EXPERIMENT_RUN_METRIC = ExperimentRunMetric(
@@ -123,9 +122,9 @@ EXPERIMENT_RUN_METRIC_BODY = {
 }
 
 EXPERIMENT_RUN_DATA_BODY = {
-    "metrics": [ExperimentRunMetricSchema().dump(EXPERIMENT_RUN_METRIC)],
-    "params": [ExperimentRunParamSchema().dump(EXPERIMENT_RUN_PARAM)],
-    "tags": [ExperimentRunTagSchema().dump(EXPERIMENT_RUN_TAG)],
+    "metrics": [EXPERIMENT_RUN_METRIC],
+    "params": [EXPERIMENT_RUN_PARAM],
+    "tags": [EXPERIMENT_RUN_TAG],
 }
 
 
@@ -198,6 +197,11 @@ def test_create_run_schema(started_at, artifact_location):
         "startedAt": RUN_STARTED_AT_STRING_PYTHON,
         "artifactLocation": artifact_location,
     }
+
+
+def test_experiment_run_schema():
+    data = ExperimentRunSchema().load(EXPERIMENT_RUN_BODY)
+    assert data == EXPERIMENT_RUN
 
 
 def test_experiment_run_metric_schema():
@@ -411,7 +415,7 @@ def test_experiment_client_list_runs_page(mocker):
     )
 
 
-def test_log_metadata(mocker):
+def test_log_run_data(mocker):
     mocker.patch.object(ExperimentClient, "_patch_raw")
     run_data_schema_mock = mocker.patch(
         "faculty.clients.experiment.ExperimentRunDataSchema"
@@ -435,7 +439,7 @@ def test_log_metadata(mocker):
     )
 
 
-def test_log_metadata_empty_data(mocker):
+def test_log_run_data_empty_data(mocker):
     mocker.patch.object(ExperimentClient, "_patch_raw")
     run_data_schema_mock = mocker.patch(
         "faculty.clients.experiment.ExperimentRunDataSchema"
@@ -452,7 +456,7 @@ def test_log_metadata_empty_data(mocker):
     )
 
 
-def test_log_metadata_multiple_tags(mocker):
+def test_log_run_data_multiple_tags(mocker):
     mocker.patch.object(ExperimentClient, "_patch_raw")
     run_data_schema_mock = mocker.patch(
         "faculty.clients.experiment.ExperimentRunDataSchema"


### PR DESCRIPTION
This PR adds models and schemas for Experiment Run Tags/Metrics/Params. An additional schema has been added called ExperimentRunDataSchema to wrap all these internally.

Note: To implement this an additional `_patch` & `_patch_raw` method were added to the base_client