### PR TITLE
Pass empty tags on run creation, return tags

### DIFF
--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -62,6 +62,8 @@ ExperimentRun = namedtuple(
         "ended_at",
         "deleted_at",
         "tags",
+        "params",
+        "metrics"
     ],
 )
 
@@ -131,6 +133,8 @@ class ExperimentRunSchema(BaseSchema):
     ended_at = fields.DateTime(data_key="endedAt", missing=None)
     deleted_at = fields.DateTime(data_key="deletedAt", missing=None)
     tags = fields.Nested(TagSchema, many=True, required=True)
+    params = fields.Nested(ParamSchema, many=True, required=True)
+    metrics = fields.Nested(MetricSchema, many=True, required=True)
 
     @post_load
     def make_experiment_run(self, data):

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -202,7 +202,12 @@ class ExperimentClient(BaseClient):
         return self._get(endpoint, ExperimentSchema(many=True))
 
     def create_run(
-        self, project_id, experiment_id, started_at, artifact_location=None
+        self,
+        project_id,
+        experiment_id,
+        started_at,
+        artifact_location=None,
+        tags=[],
     ):
         """Create a run in a project.
 
@@ -229,7 +234,7 @@ class ExperimentClient(BaseClient):
             {
                 "started_at": started_at,
                 "artifact_location": artifact_location,
-                "tags": [],
+                "tags": tags,
             }
         )
         return self._post(endpoint, ExperimentRunSchema(), json=payload)

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -123,9 +123,15 @@ class ListExperimentRunsResponseSchema(BaseSchema):
         return ListExperimentRunsResponse(**data)
 
 
+class TagSchema(BaseSchema):
+    key = fields.String(data_key="key")
+    value = fields.String(data_key="value")
+
+
 class CreateRunSchema(BaseSchema):
     started_at = fields.DateTime(data_key="startedAt")
     artifact_location = fields.String(data_key="artifactLocation")
+    tags = fields.Nested(TagSchema, many=True, required=True)
 
 
 class ExperimentClient(BaseClient):
@@ -212,7 +218,11 @@ class ExperimentClient(BaseClient):
             project_id, experiment_id
         )
         payload = CreateRunSchema().dump(
-            {"started_at": started_at, "artifact_location": artifact_location}
+            {
+                "started_at": started_at,
+                "artifact_location": artifact_location,
+                "tags": [],
+            }
         )
         return self._post(endpoint, ExperimentRunSchema(), json=payload)
 

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -63,7 +63,7 @@ ExperimentRun = namedtuple(
         "deleted_at",
         "tags",
         "params",
-        "metrics"
+        "metrics",
     ],
 )
 

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -28,6 +28,8 @@ class ExperimentRunStatus(Enum):
     SCHEDULED = "scheduled"
 
 
+Tag = namedtuple("Tag", ["key", "value"])
+
 Experiment = namedtuple(
     "Experiment",
     [
@@ -52,6 +54,7 @@ ExperimentRun = namedtuple(
         "started_at",
         "ended_at",
         "deleted_at",
+        "tags",
     ],
 )
 
@@ -60,6 +63,15 @@ Pagination = namedtuple("Pagination", ["start", "size", "previous", "next"])
 ListExperimentRunsResponse = namedtuple(
     "ListExperimentRunsResponse", ["runs", "pagination"]
 )
+
+
+class TagSchema(BaseSchema):
+    key = fields.String(data_key="key")
+    value = fields.String(data_key="value")
+
+    @post_load
+    def make_tag(self, data):
+        return Tag(**data)
 
 
 class ExperimentSchema(BaseSchema):
@@ -88,6 +100,7 @@ class ExperimentRunSchema(BaseSchema):
     started_at = fields.DateTime(data_key="startedAt", required=True)
     ended_at = fields.DateTime(data_key="endedAt", missing=None)
     deleted_at = fields.DateTime(data_key="deletedAt", missing=None)
+    tags = fields.Nested(TagSchema, many=True, required=True)
 
     @post_load
     def make_experiment_run(self, data):
@@ -121,11 +134,6 @@ class ListExperimentRunsResponseSchema(BaseSchema):
     @post_load
     def make_list_runs_response_schema(self, data):
         return ListExperimentRunsResponse(**data)
-
-
-class TagSchema(BaseSchema):
-    key = fields.String(data_key="key")
-    value = fields.String(data_key="value")
 
 
 class CreateRunSchema(BaseSchema):

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -207,7 +207,7 @@ class ExperimentClient(BaseClient):
         experiment_id,
         started_at,
         artifact_location=None,
-        tags=[],
+        tags=None,
     ):
         """Create a run in a project.
 
@@ -222,12 +222,15 @@ class ExperimentClient(BaseClient):
             The location of the artifact repository to use for this run.
             If omitted, the value of `artifact_location` for the experiment
             will be used.
-        tags: dict[str, str]
+        tags: List[Tag]
 
         Returns
         -------
         ExperimentRun
         """
+        if tags is None:
+            tags = []
+
         endpoint = "/project/{}/experiment/{}/run".format(
             project_id, experiment_id
         )

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -37,8 +37,6 @@ class ExperimentRunStatus(Enum):
     SCHEDULED = "scheduled"
 
 
-Tag = namedtuple("Tag", ["key", "value"])
-
 Experiment = namedtuple(
     "Experiment",
     [
@@ -76,15 +74,6 @@ Pagination = namedtuple("Pagination", ["start", "size", "previous", "next"])
 ListExperimentRunsResponse = namedtuple(
     "ListExperimentRunsResponse", ["runs", "pagination"]
 )
-
-
-class TagSchema(BaseSchema):
-    key = fields.String(data_key="key")
-    value = fields.String(data_key="value")
-
-    @post_load
-    def make_tag(self, data):
-        return Tag(**data)
 
 
 class ExperimentSchema(BaseSchema):

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -222,6 +222,7 @@ class ExperimentClient(BaseClient):
             The location of the artifact repository to use for this run.
             If omitted, the value of `artifact_location` for the experiment
             will be used.
+        tags: dict[str, str]
 
         Returns
         -------

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -76,6 +76,34 @@ ListExperimentRunsResponse = namedtuple(
 )
 
 
+class MetricSchema(BaseSchema):
+    key = fields.String(required=True)
+    value = fields.Float(required=True)
+    timestamp = fields.DateTime(required=True)
+
+    @post_load
+    def make_metric(self, data):
+        return Metric(**data)
+
+
+class ParamSchema(BaseSchema):
+    key = fields.String(required=True)
+    value = fields.String(required=True)
+
+    @post_load
+    def make_param(self, data):
+        return Param(**data)
+
+
+class TagSchema(BaseSchema):
+    key = fields.String(required=True)
+    value = fields.String(required=True)
+
+    @post_load
+    def make_tag(self, data):
+        return Tag(**data)
+
+
 class ExperimentSchema(BaseSchema):
     id = fields.Integer(data_key="experimentId", required=True)
     name = fields.String(required=True)
@@ -107,34 +135,6 @@ class ExperimentRunSchema(BaseSchema):
     @post_load
     def make_experiment_run(self, data):
         return ExperimentRun(**data)
-
-
-class MetricSchema(BaseSchema):
-    key = fields.String(required=True)
-    value = fields.Float(required=True)
-    timestamp = fields.DateTime(required=True)
-
-    @post_load
-    def make_metric(self, data):
-        return Metric(**data)
-
-
-class ParamSchema(BaseSchema):
-    key = fields.String(required=True)
-    value = fields.String(required=True)
-
-    @post_load
-    def make_param(self, data):
-        return Param(**data)
-
-
-class TagSchema(BaseSchema):
-    key = fields.String(required=True)
-    value = fields.String(required=True)
-
-    @post_load
-    def make_tag(self, data):
-        return Tag(**data)
 
 
 class ExperimentRunDataSchema(BaseSchema):

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -110,7 +110,7 @@ EXPERIMENT_RUN = ExperimentRun(
     deleted_at=DELETED_AT,
     tags=[TAG],
     params=[PARAM],
-    metrics=[METRIC]
+    metrics=[METRIC],
 )
 EXPERIMENT_RUN_BODY = {
     "experimentId": EXPERIMENT.id,
@@ -193,13 +193,19 @@ def test_experiment_run_schema_nullable_field(data_key, field):
     ids=["timezone", "no timezone"],
 )
 @pytest.mark.parametrize("artifact_location", [None, "faculty:project-id"])
-def test_create_run_schema(started_at, artifact_location):
+@pytest.mark.parametrize("tags", [[], [{"key": "key", "value": "value"}]])
+def test_create_run_schema(started_at, artifact_location, tags):
     data = CreateRunSchema().dump(
-        {"started_at": started_at, "artifact_location": artifact_location}
+        {
+            "started_at": started_at,
+            "artifact_location": artifact_location,
+            "tags": tags,
+        }
     )
     assert data == {
         "startedAt": RUN_STARTED_AT_STRING_PYTHON,
         "artifactLocation": artifact_location,
+        "tags": tags,
     }
 
 

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -34,6 +34,8 @@ from faculty.clients.experiment import (
     PageSchema,
     Pagination,
     PaginationSchema,
+    Tag,
+    TagSchema,
 )
 
 
@@ -74,6 +76,9 @@ RUN_STARTED_AT_STRING_JAVA = "2018-03-10T11:39:12.11Z"
 RUN_ENDED_AT = datetime(2018, 3, 10, 11, 39, 15, 110000, tzinfo=UTC)
 RUN_ENDED_AT_STRING = "2018-03-10T11:39:15.11Z"
 
+TAG = Tag(key="tag-key", value="tag-value")
+TAG_BODY = {"key": "tag-key", "value": "tag-value"}
+
 EXPERIMENT_RUN = ExperimentRun(
     id=EXPERIMENT_RUN_ID,
     experiment_id=EXPERIMENT.id,
@@ -82,6 +87,7 @@ EXPERIMENT_RUN = ExperimentRun(
     started_at=RUN_STARTED_AT,
     ended_at=RUN_ENDED_AT,
     deleted_at=DELETED_AT,
+    tags=[TAG],
 )
 EXPERIMENT_RUN_BODY = {
     "experimentId": EXPERIMENT.id,
@@ -91,6 +97,7 @@ EXPERIMENT_RUN_BODY = {
     "startedAt": RUN_STARTED_AT_STRING_JAVA,
     "endedAt": RUN_ENDED_AT_STRING,
     "deletedAt": DELETED_AT_STRING,
+    "tags": [TAG_BODY],
 }
 
 PAGE = Page(start=3, limit=10)
@@ -119,6 +126,11 @@ LIST_EXPERIMENT_RUNS_RESPONSE_BODY = {
     "runs": [EXPERIMENT_RUN_BODY],
     "pagination": PAGINATION_BODY,
 }
+
+
+def test_tag_schema():
+    data = TagSchema().load(TAG_BODY)
+    assert data == TAG
 
 
 def test_experiment_schema():

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -229,6 +229,11 @@ def test_experiment_run_tag_schema():
     assert data == TAG
 
 
+def test_experiment_run_tag_schema_dump():
+    data = TagSchema().dump(TAG_BODY)
+    assert data == TAG_BODY
+
+
 def test_experiment_run_data_schema():
     data = ExperimentRunDataSchema().dump(
         {"metrics": [METRIC], "params": [PARAM], "tags": [TAG]}

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -160,11 +160,6 @@ LIST_EXPERIMENT_RUNS_RESPONSE_BODY = {
 }
 
 
-def test_tag_schema():
-    data = TagSchema().load(TAG_BODY)
-    assert data == TAG
-
-
 def test_experiment_schema():
     data = ExperimentSchema().load(EXPERIMENT_BODY)
     assert data == EXPERIMENT

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -84,29 +84,6 @@ RUN_ENDED_AT_STRING = "2018-03-10T11:39:15.11Z"
 TAG = Tag(key="tag-key", value="tag-value")
 TAG_BODY = {"key": "tag-key", "value": "tag-value"}
 
-EXPERIMENT_RUN = ExperimentRun(
-    id=EXPERIMENT_RUN_ID,
-    experiment_id=EXPERIMENT.id,
-    artifact_location="faculty:",
-    status=ExperimentRunStatus.RUNNING,
-    started_at=RUN_STARTED_AT,
-    ended_at=RUN_ENDED_AT,
-    deleted_at=DELETED_AT,
-    tags=[TAG],
-)
-EXPERIMENT_RUN_BODY = {
-    "experimentId": EXPERIMENT.id,
-    "runId": str(EXPERIMENT_RUN_ID),
-    "artifactLocation": "faculty:",
-    "status": "running",
-    "startedAt": RUN_STARTED_AT_STRING_JAVA,
-    "endedAt": RUN_ENDED_AT_STRING,
-    "deletedAt": DELETED_AT_STRING,
-    "tags": [TAG_BODY],
-}
-TAG = Tag(key="tag-key", value="tag-value")
-TAG_BODY = {"key": "tag-key", "value": "tag-value"}
-
 OTHER_TAG = Tag(key="other-tag-key", value="other-tag-value")
 OTHER_TAG_BODY = {"key": "other-tag-key", "value": "other-tag-value"}
 
@@ -121,6 +98,31 @@ METRIC_BODY = {
     "key": "metric-key",
     "value": 123.0,
     "timestamp": METRIC_TIMESTAMP_STRING_PYTHON,
+}
+
+EXPERIMENT_RUN = ExperimentRun(
+    id=EXPERIMENT_RUN_ID,
+    experiment_id=EXPERIMENT.id,
+    artifact_location="faculty:",
+    status=ExperimentRunStatus.RUNNING,
+    started_at=RUN_STARTED_AT,
+    ended_at=RUN_ENDED_AT,
+    deleted_at=DELETED_AT,
+    tags=[TAG],
+    params=[PARAM],
+    metrics=[METRIC]
+)
+EXPERIMENT_RUN_BODY = {
+    "experimentId": EXPERIMENT.id,
+    "runId": str(EXPERIMENT_RUN_ID),
+    "artifactLocation": "faculty:",
+    "status": "running",
+    "startedAt": RUN_STARTED_AT_STRING_JAVA,
+    "endedAt": RUN_ENDED_AT_STRING,
+    "deletedAt": DELETED_AT_STRING,
+    "tags": [TAG_BODY],
+    "metrics": [METRIC_BODY],
+    "params": [PARAM_BODY],
 }
 
 EXPERIMENT_RUN_DATA_BODY = {

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -244,7 +244,11 @@ def test_experiment_create_run(mocker):
 
     request_schema_mock.assert_called_once_with()
     dump_mock.assert_called_once_with(
-        {"started_at": started_at, "artifact_location": artifact_location}
+        {
+            "started_at": started_at,
+            "artifact_location": artifact_location,
+            "tags": [],
+        }
     )
     response_schema_mock.assert_called_once_with()
     ExperimentClient._post.assert_called_once_with(

--- a/tests/clients/test_experiment.py
+++ b/tests/clients/test_experiment.py
@@ -214,22 +214,22 @@ def test_experiment_run_schema():
     assert data == EXPERIMENT_RUN
 
 
-def test_experiment_run_metric_schema():
+def test_metric_schema():
     data = MetricSchema().load(METRIC_BODY)
     assert data == METRIC
 
 
-def test_experiment_run_param_schema():
+def test_param_schema():
     data = ParamSchema().load(PARAM_BODY)
     assert data == PARAM
 
 
-def test_experiment_run_tag_schema():
+def test_tag_schema():
     data = TagSchema().load(TAG_BODY)
     assert data == TAG
 
 
-def test_experiment_run_tag_schema_dump():
+def test_tag_schema_dump():
     data = TagSchema().dump(TAG_BODY)
     assert data == TAG_BODY
 


### PR DESCRIPTION
At the moment, the backend requires `tags` to be passed in the request to create a run. This fixes it by passing empty tags for now.

The next step is to pass through tags from mlflow-faculty to this client.

Also, tag schema was added to the run schema (used when fetching runs).