### PR TITLE
Remove InvalidResponse custom exception

### DIFF
--- a/faculty/clients/base.py
+++ b/faculty/clients/base.py
@@ -18,10 +18,6 @@ from marshmallow import Schema, fields, ValidationError, EXCLUDE
 from faculty.clients.auth import FacultyAuth
 
 
-class InvalidResponse(Exception):
-    pass
-
-
 class HttpError(Exception):
     def __init__(self, response, error=None, error_code=None):
         self.response = response
@@ -107,19 +103,8 @@ def _check_status(response):
 
 
 def _deserialise_response(schema, response):
-    try:
-        response_json = response.json()
-    except ValueError:
-        raise InvalidResponse("response body was not valid JSON")
-
-    try:
-        data = schema.load(response_json)
-    except ValidationError:
-        # TODO: log validation errors and possibly include them in raised
-        # exception
-        raise InvalidResponse("response content did not match expected format")
-
-    return data
+    response_json = response.json()
+    return schema.load(response_json)
 
 
 class BaseClient(object):

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -16,7 +16,7 @@
 from collections import namedtuple
 
 import pytest
-from marshmallow import fields, post_load
+from marshmallow import fields, post_load, ValidationError
 
 from faculty.clients.base import (
     BadGateway,
@@ -29,7 +29,6 @@ from faculty.clients.base import (
     GatewayTimeout,
     HttpError,
     InternalServerError,
-    InvalidResponse,
     MethodNotAllowed,
     NotFound,
     ServiceUnavailable,
@@ -270,7 +269,7 @@ def test_invalid_json(requests_mock, session, patch_auth, http_method):
 
     client = DummyClient(session)
     method = getattr(client, "_{}".format(http_method.lower()))
-    with pytest.raises(InvalidResponse, match="not valid JSON"):
+    with pytest.raises(ValueError):
         method(MOCK_ENDPOINT, DummySchema())
 
 
@@ -286,5 +285,5 @@ def test_malformatted_json(requests_mock, session, patch_auth, http_method):
 
     client = DummyClient(session)
     method = getattr(client, "_{}".format(http_method.lower()))
-    with pytest.raises(InvalidResponse, match="not match expected format"):
+    with pytest.raises(ValidationError):
         method(MOCK_ENDPOINT, DummySchema())


### PR DESCRIPTION
Current logic is supressing information that would make it possible to
diagnose issues. Decided just to surface the original exceptions so we
can actually see the errors.