### PR TITLE
Install marshmallow recommended dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ setup(
         "pytz",
         "six",
         "enum34; python_version<'3.4'",
+        # Install marshmallow with 'reco' (recommended) extras to ensure a
+        # compatible version of python-dateutil is available
         "marshmallow[reco]==3.0.0rc3",
         "marshmallow_enum",
         "boto3",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "pytz",
         "six",
         "enum34; python_version<'3.4'",
-        "marshmallow==3.0.0rc3",
+        "marshmallow[reco]==3.0.0rc3",
         "marshmallow_enum",
         "boto3",
         "botocore",


### PR DESCRIPTION
This is to correct an error where python-dateutil is installed, but of a version incompatible with marshmallow. The [reco] extras ensures that a version supported by marshmallow is installed.