### PR TITLE
Read region from secret service response

### DIFF
--- a/faculty/clients/secret.py
+++ b/faculty/clients/secret.py
@@ -19,7 +19,8 @@ from marshmallow import fields, post_load
 from faculty.clients.base import BaseSchema, BaseClient
 
 DatasetsSecrets = namedtuple(
-    "DatasetsSecrets", ["bucket", "access_key", "secret_key", "verified"]
+    "DatasetsSecrets",
+    ["bucket", "access_key", "secret_key", "region", "verified"],
 )
 
 
@@ -27,6 +28,7 @@ class DatasetsSecretsSchema(BaseSchema):
     bucket = fields.String(required=True)
     access_key = fields.String(required=True)
     secret_key = fields.String(required=True)
+    region = fields.String(required=True)
     verified = fields.Boolean(required=True)
 
     @post_load

--- a/faculty/datasets/session.py
+++ b/faculty/datasets/session.py
@@ -87,7 +87,7 @@ class DatasetsSession(object):
         boto_session = boto3.session.Session(
             aws_access_key_id=secrets.access_key,
             aws_secret_access_key=secrets.secret_key,
-            region_name="eu-west-1",
+            region_name=secrets.region,
         )
 
         return boto_session.client("s3")

--- a/tests/clients/test_secret.py
+++ b/tests/clients/test_secret.py
@@ -23,6 +23,7 @@ TEST_SECRETS = DatasetsSecrets(
     bucket="test-bucket",
     access_key="test-access-key",
     secret_key="test-secret-key",
+    region="test-region",
     verified=True,
 )
 
@@ -30,6 +31,7 @@ TEST_SECRETS_BODY = {
     "bucket": TEST_SECRETS.bucket,
     "access_key": TEST_SECRETS.access_key,
     "secret_key": TEST_SECRETS.secret_key,
+    "region": TEST_SECRETS.region,
     "verified": TEST_SECRETS.verified,
 }
 

--- a/tests/datasets/conftest.py
+++ b/tests/datasets/conftest.py
@@ -43,6 +43,7 @@ def _test_secrets():
         bucket=TEST_BUCKET_NAME,
         access_key=os.environ["AWS_ACCESS_KEY_ID"],
         secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        region=os.environ["AWS_REGION"],
         verified=True,
     )
 

--- a/tests/datasets/fixtures.py
+++ b/tests/datasets/fixtures.py
@@ -88,6 +88,7 @@ def _test_secrets():
         bucket=TEST_BUCKET_NAME,
         access_key=os.environ["AWS_ACCESS_KEY_ID"],
         secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        region=os.environ["AWS_REGION"],
         verified=True,
     )
 
@@ -102,7 +103,7 @@ def s3_client():
         boto_session = boto3.session.Session(
             aws_access_key_id=secrets.access_key,
             aws_secret_access_key=secrets.secret_key,
-            region_name="eu-west-1",
+            region_name=secrets.region,
         )
         _S3_CLIENT_CACHE = boto_session.client("s3")
     return _S3_CLIENT_CACHE


### PR DESCRIPTION
[DNM until https://bitbucket.org/theasi/secret-service/pull-requests/112/send-region-information/diff is merged]
This PR changes the datasets feature to use the AWS region returned from the secret-service as opposed to a hardcoded value. 