### PR TITLE
Change marshmallow dependency to lower bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "enum34; python_version<'3.4'",
         # Install marshmallow with 'reco' (recommended) extras to ensure a
         # compatible version of python-dateutil is available
-        "marshmallow[reco]==3.0.0rc3",
+        "marshmallow[reco]>=3.0.0rc3",
         "marshmallow_enum",
         "boto3",
         "botocore",


### PR DESCRIPTION
The Marshmallow developers have released additional release candidates since 3.0.0rc3, which other dependencies in my project depend on. Therefore change the exact version bound to a lower bound, to prevent spurious warnings such as
```
faculty 0.23.1 has requirement marshmallow[reco]==3.0.0rc3, but you'll have marshmallow 3.0.0rc5 which is incompatible.
```
printed by pip when installing such other dependencies.