### PR TITLE
Change delete_runs/restore_runs in experiment client to use the new filtered endpoint

### DIFF
--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -628,12 +628,14 @@ class ExperimentClient(BaseClient):
         """
         endpoint = "/project/{}/run/delete/query".format(project_id)
 
-        payload = {}
-        if run_ids is not None:
-            if len(run_ids) == 0:
-                return DeleteExperimentRunsResponse(
-                    deleted_run_ids=[], conflicted_run_ids=[]
-                )
+        if run_ids is None:
+            # Delete all runs in project
+            payload = {}  # No filter
+        elif len(run_ids) == 0:
+            return DeleteExperimentRunsResponse(
+                deleted_run_ids=[], conflicted_run_ids=[]
+            )
+        else:
             payload = {
                 "filter": {
                     "operator": "or",
@@ -667,12 +669,14 @@ class ExperimentClient(BaseClient):
         """
         endpoint = "/project/{}/run/restore/query".format(project_id)
 
-        payload = {}
-        if run_ids is not None:
-            if len(run_ids) == 0:
-                return RestoreExperimentRunsResponse(
-                    restored_run_ids=[], conflicted_run_ids=[]
-                )
+        if run_ids is None:
+            # Restore all runs in project
+            payload = {}  # No filter
+        elif len(run_ids) == 0:
+            return RestoreExperimentRunsResponse(
+                restored_run_ids=[], conflicted_run_ids=[]
+            )
+        else:
             payload = {
                 "filter": {
                     "operator": "or",


### PR DESCRIPTION
Also, delete/restore no runs if [] is passed. It seems intuitive to not delete/restore anything if `[]` is passed and this makes it consistent with `list_runs`.

This can be merged tomorrow (when the new backend is in place).

Changing the behaviour for the empty list is itself a breaking change, but I'd suggest not bumping minor - in my mind it's a bugfix - hopefully no one was relying on this behaviour, or do people have other thoughts?