### PR TITLE
Change the DEFAULT_DOMAIN entry

### DIFF
--- a/faculty/config.py
+++ b/faculty/config.py
@@ -10,7 +10,7 @@ Profile = namedtuple(
 )
 
 DEFAULT_PROFILE = "default"
-DEFAULT_DOMAIN = "services.sherlockml.com"
+DEFAULT_DOMAIN = "services.cloud.my.faculty.ai"
 DEFAULT_PROTOCOL = "https"
 
 


### PR DESCRIPTION
When using `faculty login` from the faculty-cli library the DEFAULT_DOMAIN in the faculty library is what is suggested. I believe the existing entry refers to the cloud deployment (?) and as such I've changed the default to reflect that. The current value is confusing. 

A potential alternative would be to require user input and validate it `^services\.[a-z0-9_\-]*\.my.faculty.ai` (untested). 