### PR TITLE
Add server context helper

### DIFF
--- a/faculty/context.py
+++ b/faculty/context.py
@@ -52,7 +52,7 @@ def _get_environ_as_type(key, cls):
     except ValueError:
         # Badly formatted
         template = (
-            "Error interpreting badly formatted environment varaible {}={}"
+            "Error interpreting badly formatted environment variable {}={}"
         )
         warnings.warn(template.format(key, os.environ[key]))
         return None

--- a/faculty/context.py
+++ b/faculty/context.py
@@ -1,0 +1,74 @@
+# Copyright 2018-2019 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from uuid import UUID
+
+from attr import attrs, attrib
+
+
+@attrs
+class PlatformContext(object):
+    """Information about the runtime context in Faculty platform."""
+
+    project_id = attrib()
+
+    server_id = attrib()
+    server_name = attrib()
+    server_cpus = attrib()
+    server_gpus = attrib()
+    server_memory_mb = attrib()
+
+    app_id = attrib()
+    api_id = attrib()
+
+    job_id = attrib()
+    job_name = attrib()
+    job_run_id = attrib()
+    job_run_number = attrib()
+    job_subrun_id = attrib()
+    job_subrun_number = attrib()
+
+
+def _get_environ_as_type(key, cls):
+    try:
+        return cls(os.environ[key])
+    except (KeyError, ValueError):
+        return None
+
+
+def get_context():
+    """Get information about the Faculty platform runtime context.
+
+    Returns
+    -------
+    PlatformContext
+    """
+    return PlatformContext(
+        project_id=_get_environ_as_type("FACULTY_PROJECT_ID", UUID),
+        server_id=_get_environ_as_type("FACULTY_SERVER_ID", UUID),
+        server_name=_get_environ_as_type("FACULTY_SERVER_NAME", str),
+        server_cpus=_get_environ_as_type("NUM_CPUS", int),
+        server_gpus=_get_environ_as_type("NUM_GPUS", int),
+        server_memory_mb=_get_environ_as_type("AVAILABLE_MEMORY_MB", int),
+        app_id=_get_environ_as_type("FACULTY_APP_ID", UUID),
+        api_id=_get_environ_as_type("FACULTY_API_ID", UUID),
+        job_id=_get_environ_as_type("FACULTY_JOB_ID", UUID),
+        job_name=_get_environ_as_type("FACULTY_JOB_NAME", str),
+        job_run_id=_get_environ_as_type("FACULTY_RUN_ID", UUID),
+        job_run_number=_get_environ_as_type("FACULTY_RUN_NUMBER", int),
+        job_subrun_id=_get_environ_as_type("FACULTY_SUBRUN_ID", UUID),
+        job_subrun_number=_get_environ_as_type("FACULTY_SUBRUN_NUMBER", int),
+    )

--- a/faculty/context.py
+++ b/faculty/context.py
@@ -14,6 +14,7 @@
 
 
 import os
+import warnings
 from uuid import UUID
 
 from attr import attrs, attrib
@@ -45,7 +46,15 @@ class PlatformContext(object):
 def _get_environ_as_type(key, cls):
     try:
         return cls(os.environ[key])
-    except (KeyError, ValueError):
+    except KeyError:
+        # Not in environment
+        return None
+    except ValueError:
+        # Badly formatted
+        template = (
+            "Error interpreting badly formatted environment varaible {}={}"
+        )
+        warnings.warn(template.format(key, os.environ[key]))
         return None
 
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "enum34; python_version<'3.4'",
         # Install marshmallow with 'reco' (recommended) extras to ensure a
         # compatible version of python-dateutil is available
+        "attr",
         "marshmallow[reco]==3.0.0rc3",
         "marshmallow_enum",
         "marshmallow-oneofschema==2.0.0b2",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "enum34; python_version<'3.4'",
         # Install marshmallow with 'reco' (recommended) extras to ensure a
         # compatible version of python-dateutil is available
-        "attr",
+        "attrs",
         "marshmallow[reco]==3.0.0rc3",
         "marshmallow_enum",
         "marshmallow-oneofschema==2.0.0b2",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,70 @@
+# Copyright 2018-2019 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from uuid import uuid4
+
+import attr
+
+from faculty.context import PlatformContext, get_context
+
+
+CONTEXT = PlatformContext(
+    project_id=uuid4(),
+    server_id=uuid4(),
+    server_name="mad_boltzmann",
+    server_cpus=2,
+    server_gpus=0,
+    server_memory_mb=8000,
+    app_id=uuid4(),
+    api_id=uuid4(),
+    job_id=uuid4(),
+    job_name="retrain model",
+    job_run_id=uuid4(),
+    job_run_number=6,
+    job_subrun_id=uuid4(),
+    job_subrun_number=2,
+)
+
+MOCK_ENVIRON = {
+    "FACULTY_PROJECT_ID": str(CONTEXT.project_id),
+    "FACULTY_SERVER_ID": str(CONTEXT.server_id),
+    "FACULTY_SERVER_NAME": CONTEXT.server_name,
+    "NUM_CPUS": str(CONTEXT.server_cpus),
+    "NUM_GPUS": str(CONTEXT.server_gpus),
+    "AVAILABLE_MEMORY_MB": str(CONTEXT.server_memory_mb),
+    "FACULTY_APP_ID": str(CONTEXT.app_id),
+    "FACULTY_API_ID": str(CONTEXT.api_id),
+    "FACULTY_JOB_ID": str(CONTEXT.job_id),
+    "FACULTY_JOB_NAME": CONTEXT.job_name,
+    "FACULTY_RUN_ID": str(CONTEXT.job_run_id),
+    "FACULTY_RUN_NUMBER": str(CONTEXT.job_run_number),
+    "FACULTY_SUBRUN_ID": str(CONTEXT.job_subrun_id),
+    "FACULTY_SUBRUN_NUMBER": str(CONTEXT.job_subrun_number),
+}
+
+
+def test_get_context(mocker):
+    mocker.patch.dict(os.environ, MOCK_ENVIRON)
+    assert get_context() == CONTEXT
+
+
+def test_get_context_defaults(mocker):
+    """Check that context fields default to None when not available."""
+    mocker.patch.dict(os.environ, {})
+    expected_context = PlatformContext(
+        **{attribute.name: None for attribute in attr.fields(PlatformContext)}
+    )
+    assert get_context() == expected_context


### PR DESCRIPTION
This provides a convenience interface for getting information about the server context that will be used by the resource-based interface in a subsequent PR.