### PR TITLE
Pin version of marshmallow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "enum34; python_version<'3.4'",
         # Install marshmallow with 'reco' (recommended) extras to ensure a
         # compatible version of python-dateutil is available
-        "marshmallow[reco]>=3.0.0rc3",
+        "marshmallow[reco]==3.0.0rc3",
         "marshmallow_enum",
         "marshmallow-oneofschema==2.0.0b2",
         "boto3",


### PR DESCRIPTION
The newest version of marshmallow introduced backwards incompatible changes that are incompatible with our code:
-  Include key-word arguments ```many``` and ```partial``` in decorated methods e.g. ```pre_load```, ```post_load```, etc. 

Therefore, many tests are not passing because of this. Pinning the version of marshmallow to an older version could solve this problem for the time being.