### PR TITLE
Vendor marshmallow-oneofschema

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,5 +8,5 @@ A Python library for interacting with `the Faculty platform <https://faculty.ai/
 
 This project is licensed under the Apache License, Version 2.0, except for the
 vendored `marshmallow-oneofschema <https://github.com/marshmallow-code/marshmallow-oneofschema>`_,
-which is licensed under the MIT license (see faculty/_oneofschema.py for
+which is licensed under the MIT license (see ``faculty/_oneofschema.py`` for
 copyright and license detail).

--- a/README.rst
+++ b/README.rst
@@ -5,3 +5,8 @@ faculty
     :target: https://travis-ci.org/facultyai/faculty
 
 A Python library for interacting with `the Faculty platform <https://faculty.ai/products-services/platform/>`_.
+
+This project is licensed under the Apache License, Version 2.0, except for the
+vendored `marshmallow-oneofschema <https://github.com/marshmallow-code/marshmallow-oneofschema>`_,
+which is licensed under the MIT license (see faculty/_oneofschema.py for
+copyright and license detail).

--- a/faculty/_oneofschema.py
+++ b/faculty/_oneofschema.py
@@ -1,0 +1,206 @@
+# This is a vendored copy of marshmallow-oneofschema 2.0.0b2:
+# https://github.com/marshmallow-code/marshmallow-oneofschema
+#
+# Copyright 2016-2017 Maxim Kulkin
+# Copyright 2018 Alex Rothberg and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+from marshmallow import Schema, ValidationError
+
+
+class OneOfSchema(Schema):
+    """
+    This is a special kind of schema that actually multiplexes other schemas
+    based on object type. When serializing values, it uses get_obj_type()
+    method to get object type name. Then it uses `type_schemas` name-to-Schema
+    mapping to get schema for that particular object type, serializes object
+    using that schema and adds an extra "type" field with name of object type.
+    Deserialization is reverse.
+    Example:
+        class Foo(object):
+            def __init__(self, foo):
+                self.foo = foo
+        class Bar(object):
+            def __init__(self, bar):
+                self.bar = bar
+        class FooSchema(marshmallow.Schema):
+            foo = marshmallow.fields.String(required=True)
+            @marshmallow.post_load
+            def make_foo(self, data):
+                return Foo(**data)
+        class BarSchema(marshmallow.Schema):
+            bar = marshmallow.fields.Integer(required=True)
+            @marshmallow.post_load
+            def make_bar(self, data):
+                return Bar(**data)
+        class MyUberSchema(marshmallow.OneOfSchema):
+            type_schemas = {
+                'foo': FooSchema,
+                'bar': BarSchema,
+            }
+            def get_obj_type(self, obj):
+                if isinstance(obj, Foo):
+                    return 'foo'
+                elif isinstance(obj, Bar):
+                    return 'bar'
+                else:
+                    raise Exception('Unknown object type: %s' % repr(obj))
+        MyUberSchema().dump([Foo(foo='hello'), Bar(bar=123)], many=True).data
+        # => [{'type': 'foo', 'foo': 'hello'}, {'type': 'bar', 'bar': 123}]
+    You can control type field name added to serialized object representation
+    by setting `type_field` class property.
+    """
+
+    type_field = "type"
+    type_field_remove = True
+    type_schemas = []
+
+    def get_obj_type(self, obj):
+        """Returns name of object schema"""
+        return obj.__class__.__name__
+
+    def dump(self, obj, many=None, **kwargs):
+        errors = {}
+        result_data = []
+        result_errors = {}
+        many = self.many if many is None else bool(many)
+        if not many:
+            result = result_data = self._dump(obj, **kwargs)
+        else:
+            for idx, o in enumerate(obj):
+                try:
+                    result = self._dump(o, **kwargs)
+                    result_data.append(result)
+                except ValidationError as error:
+                    result_errors[idx] = error.messages
+                    result_data.append(error.valid_data)
+
+        result = result_data
+        errors = result_errors
+
+        if not errors:
+            return result
+        else:
+            exc = ValidationError(errors, data=obj, valid_data=result)
+            raise exc
+
+    def _dump(self, obj, update_fields=True, **kwargs):
+        obj_type = self.get_obj_type(obj)
+        if not obj_type:
+            return (
+                None,
+                {
+                    "_schema": "Unknown object class: %s"
+                    % obj.__class__.__name__
+                },
+            )
+
+        type_schema = self.type_schemas.get(obj_type)
+        if not type_schema:
+            return None, {"_schema": "Unsupported object type: %s" % obj_type}
+
+        schema = (
+            type_schema if isinstance(type_schema, Schema) else type_schema()
+        )
+
+        schema.context.update(getattr(self, "context", {}))
+
+        result = schema.dump(obj, many=False, **kwargs)
+        if result is not None:
+            result[self.type_field] = obj_type
+        return result
+
+    def load(self, data, many=None, partial=None, unknown=None):
+        errors = {}
+        result_data = []
+        result_errors = {}
+        many = self.many if many is None else bool(many)
+        if partial is None:
+            partial = self.partial
+        if not many:
+            try:
+                result = result_data = self._load(
+                    data, partial=partial, unknown=unknown
+                )
+                #  result_data.append(result)
+            except ValidationError as error:
+                result_errors[0] = error.messages
+                result_data.append(error.valid_data)
+        else:
+            for idx, item in enumerate(data):
+                try:
+                    result = self._load(item, partial=partial)
+                    result_data.append(result)
+                except ValidationError as error:
+                    result_errors[idx] = error.messages
+                    result_data.append(error.valid_data)
+
+        result = result_data
+        errors = result_errors
+
+        if not errors:
+            return result
+        else:
+            exc = ValidationError(errors, data=data, valid_data=result)
+            raise exc
+
+    def _load(self, data, partial=None, unknown=None):
+        if not isinstance(data, dict):
+            raise ValidationError({"_schema": "Invalid data type: %s" % data})
+
+        data = dict(data)
+        unknown = unknown or self.unknown
+
+        data_type = data.get(self.type_field)
+        if self.type_field in data and self.type_field_remove:
+            data.pop(self.type_field)
+
+        if not data_type:
+            raise ValidationError(
+                {self.type_field: ["Missing data for required field."]}
+            )
+
+        try:
+            type_schema = self.type_schemas.get(data_type)
+        except TypeError:
+            # data_type could be unhashable
+            raise ValidationError(
+                {self.type_field: ["Invalid value: %s" % data_type]}
+            )
+        if not type_schema:
+            raise ValidationError(
+                {self.type_field: ["Unsupported value: %s" % data_type]}
+            )
+
+        schema = (
+            type_schema if isinstance(type_schema, Schema) else type_schema()
+        )
+
+        schema.context.update(getattr(self, "context", {}))
+
+        return schema.load(data, many=False, partial=partial, unknown=unknown)
+
+    def validate(self, data, many=None, partial=None):
+        try:
+            self.load(data, many=many, partial=partial)
+        except ValidationError as ve:
+            return ve.messages
+        return {}

--- a/faculty/clients/experiment/_schemas.py
+++ b/faculty/clients/experiment/_schemas.py
@@ -15,8 +15,8 @@
 
 from marshmallow import fields, post_load, pre_dump, ValidationError
 from marshmallow_enum import EnumField
-from marshmallow_oneofschema import OneOfSchema
 
+from faculty._oneofschema import OneOfSchema
 from faculty.clients.base import BaseSchema
 from faculty.clients.experiment._models import (
     ComparisonOperator,

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         "attrs",
         "marshmallow[reco]==3.0.0rc3",
         "marshmallow_enum",
-        "marshmallow-oneofschema==2.0.0b2",
         "boto3",
         "botocore",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -30,4 +30,4 @@ skip_install = True
 deps =
     apache-license-check
 commands =
-    apache-license-check --copyright "Faculty Science Limited" setup.py faculty tests
+    apache-license-check setup.py faculty tests --exclude faculty/_oneofschema.py --copyright "Faculty Science Limited"


### PR DESCRIPTION
This is to avoid annoying dependency version conflicts until we adopt the final marshmallow 1.0 release, which will require dropping Python 2 support.