### PR TITLE
Fix adding apt packages when creating environments

### DIFF
--- a/faculty/clients/environment.py
+++ b/faculty/clients/environment.py
@@ -40,7 +40,7 @@ Pip = namedtuple("Pip", ["extra_index_urls", "packages"])
 Conda = namedtuple("Conda", ["channels", "packages"])
 PythonEnvironment = namedtuple("PythonEnvironment", ["pip", "conda"])
 Apt = namedtuple("Apt", ["packages"])
-AptPackage = namedtuple("AptPackage", ["name"])
+AptPackage = namedtuple("AptPackage", ["name", "version"])
 Script = namedtuple("Script", ["script"])
 PythonSpecification = namedtuple("PythonSpecification", ["python2", "python3"])
 Specification = namedtuple("Specification", ["apt", "bash", "python"])
@@ -62,18 +62,22 @@ EnvironmentCreateUpdate = namedtuple(
     "EnvironmentCreateUpdate", ["name", "description", "specification"]
 )
 
-VERSION_REGEX = re.compile(
+PYTHON_VERSION_REGEX = re.compile(
     r"^(?:\d+\!)?\d+(?:\.\d+)*(?:(?:a|b|rc)\d+)?(?:\.post\d+)?(?:\.dev\d+)?$"
 )
 
+APT_VERSION_REGEX = re.compile(
+    r"^[a-zA-Z0-9\\.\\+-:~]+$"
+)
 
-class VersionSchema(BaseSchema):
+
+class PythonVersionSchema(BaseSchema):
     constraint = EnumField(Constraint, by_value=True, required=True)
     identifier = fields.String(required=True)
 
     @validates("identifier")
     def validate_version_format(self, data):
-        if not VERSION_REGEX.match(data):
+        if not PYTHON_VERSION_REGEX.match(data):
             raise ValidationError("Invalid version format")
 
     @post_load
@@ -86,7 +90,31 @@ class VersionSchema(BaseSchema):
         return data
 
 
-class VersionField(fields.Field):
+class VersionSchema(PythonVersionSchema):
+    # TODO: deprecation warning
+    pass
+
+
+class AptVersionSchema(BaseSchema):
+    constraint = EnumField(Constraint, by_value=True, required=True)
+    identifier = fields.String(required=True)
+
+    @validates("identifier")
+    def validate_version_format(self, data):
+        if not APT_VERSION_REGEX.match(data):
+            raise ValidationError("Invalid version format")
+
+    @post_load
+    def make_version(self, data):
+        return Version(**data)
+
+    @post_dump
+    def dump_version(self, data):
+        self.validate_version_format(data["identifier"])
+        return data
+
+
+class PythonVersionField(fields.Field):
     """
     Field that serialises/deserialises a Python package version.
     """
@@ -95,18 +123,41 @@ class VersionField(fields.Field):
         if value == "latest":
             return "latest"
         else:
-            return VersionSchema().load(value)
+            return PythonVersionSchema().load(value)
 
     def _serialize(self, value, attr, obj, **kwargs):
         if value == "latest":
             return "latest"
         else:
-            return VersionSchema().dump(value)
+            return PythonVersionSchema().dump(value)
+
+
+class VersionField(PythonVersionField):
+    # TODO: deprecation warning
+    pass
+
+
+class AptVersionField(fields.Field):
+    """
+    Field that serialises/deserialises an apt package version.
+    """
+
+    def _deserialize(self, value, attr, obj, **kwargs):
+        if value == "latest":
+            return "latest"
+        else:
+            return AptVersionSchema().load(value)
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if value == "latest":
+            return "latest"
+        else:
+            return AptVersionSchema().dump(value)
 
 
 class PythonPackageSchema(BaseSchema):
     name = fields.String(required=True)
-    version = VersionField(required=True)
+    version = PythonVersionField(required=True)
 
     @post_load
     def make_python_package(self, data):
@@ -157,6 +208,7 @@ class PythonSpecificationSchema(BaseSchema):
 
 class AptPackageSchema(BaseSchema):
     name = fields.String(required=True)
+    version = AptVersionField(required=True)
 
     @post_load
     def make_apt_package(self, data):

--- a/faculty/clients/environment.py
+++ b/faculty/clients/environment.py
@@ -16,6 +16,7 @@
 import re
 from collections import namedtuple
 from enum import Enum
+import warnings
 
 from marshmallow import (
     ValidationError,
@@ -91,8 +92,13 @@ class PythonVersionSchema(BaseSchema):
 
 
 class VersionSchema(PythonVersionSchema):
-    # TODO: deprecation warning
-    pass
+    def __init__(self, *args, **kwargs):
+        template = (
+            "The class VersionSchema is deprecated. "
+            "Please migrate by using PythonVersionSchema."
+        )
+        warnings.warn(template)
+        super(VersionSchema, self).__init__(*args, **kwargs)
 
 
 class AptVersionSchema(BaseSchema):
@@ -133,8 +139,13 @@ class PythonVersionField(fields.Field):
 
 
 class VersionField(PythonVersionField):
-    # TODO: deprecation warning
-    pass
+    def __init__(self, *args, **kwargs):
+        template = (
+            "The class VersionField is deprecated. "
+            "Please migrate by using PythonVersionField."
+        )
+        warnings.warn(template)
+        super(VersionSchema, self).__init__(*args, **kwargs)
 
 
 class AptVersionField(fields.Field):

--- a/faculty/clients/environment.py
+++ b/faculty/clients/environment.py
@@ -16,7 +16,6 @@
 import re
 from collections import namedtuple
 from enum import Enum
-import warnings
 
 from marshmallow import (
     ValidationError,
@@ -89,16 +88,6 @@ class PythonVersionSchema(BaseSchema):
         return data
 
 
-class VersionSchema(PythonVersionSchema):
-    def __init__(self, *args, **kwargs):
-        template = (
-            "The class VersionSchema is deprecated. "
-            "Please migrate by using PythonVersionSchema."
-        )
-        warnings.warn(template)
-        super(VersionSchema, self).__init__(*args, **kwargs)
-
-
 class AptVersionSchema(BaseSchema):
     constraint = EnumField(Constraint, by_value=True, required=True)
     identifier = fields.String(required=True)
@@ -134,16 +123,6 @@ class PythonVersionField(fields.Field):
             return "latest"
         else:
             return PythonVersionSchema().dump(value)
-
-
-class VersionField(PythonVersionField):
-    def __init__(self, *args, **kwargs):
-        template = (
-            "The class VersionField is deprecated. "
-            "Please migrate by using PythonVersionField."
-        )
-        warnings.warn(template)
-        super(VersionSchema, self).__init__(*args, **kwargs)
 
 
 class AptVersionField(fields.Field):

--- a/faculty/clients/environment.py
+++ b/faculty/clients/environment.py
@@ -67,9 +67,7 @@ PYTHON_VERSION_REGEX = re.compile(
     r"^(?:\d+\!)?\d+(?:\.\d+)*(?:(?:a|b|rc)\d+)?(?:\.post\d+)?(?:\.dev\d+)?$"
 )
 
-APT_VERSION_REGEX = re.compile(
-    r"^[a-zA-Z0-9\\.\\+-:~]+$"
-)
+APT_VERSION_REGEX = re.compile(r"^[a-zA-Z0-9\\.\\+-:~]+$")
 
 
 class PythonVersionSchema(BaseSchema):

--- a/tests/clients/test_environment.py
+++ b/tests/clients/test_environment.py
@@ -86,8 +86,8 @@ CONDA = Conda(channels=["conda-forge"], packages=[PYTHON_PACKAGE])
 PYTHON_ENVIRONMENT_BODY = {"pip": PIP_BODY, "conda": CONDA_BODY}
 PYTHON_ENVIRONMENT = PythonEnvironment(conda=CONDA, pip=PIP)
 
-APT_PACKAGE_BODY = {"name": "cuda"}
-APT_PACKAGE = AptPackage(name="cuda")
+APT_PACKAGE_BODY = {"name": "cuda", "version": "latest"}
+APT_PACKAGE = AptPackage(name="cuda", version="latest")
 
 APT_BODY = {"packages": [APT_PACKAGE_BODY]}
 APT = Apt(packages=[APT_PACKAGE])

--- a/tests/clients/test_environment.py
+++ b/tests/clients/test_environment.py
@@ -24,6 +24,7 @@ from faculty.clients.environment import (
     AptPackage,
     AptPackageSchema,
     AptSchema,
+    AptVersionSchema,
     Conda,
     CondaSchema,
     Constraint,
@@ -56,9 +57,13 @@ VERSION = Version(constraint=Constraint.EQUAL, identifier="1.0.0")
 VERSION_BODY_LATEST = "latest"
 VERSION_LATEST = "latest"
 
-INVALID_VERSION_BODY = {"constraint": "==", "identifier": "invalid-identifier"}
-INVALID_VERSION = Version(
+INVALID_PYTHON_VERSION_BODY = {"constraint": "==", "identifier": "invalid-identifier"}
+INVALID_PYTHON_VERSION = Version(
     constraint=Constraint.EQUAL, identifier="invalid-identifier"
+)
+INVALID_APT_VERSION_BODY = {"constraint": "==", "identifier": "    "}
+INVALID_APT_VERSION = Version(
+    constraint=Constraint.EQUAL, identifier="    "
 )
 
 PYTHON_PACKAGE_BODY = {"name": "tensorflow", "version": VERSION_BODY}
@@ -187,25 +192,44 @@ ENVIRONMENT_CREATE_UPDATE_NO_DESCRIPTION = EnvironmentCreateUpdate(
 )
 
 
-def test_version_schema_load():
+def test_python_version_schema_load():
     data = PythonVersionSchema().load(VERSION_BODY)
     assert data == VERSION
 
 
-def test_version_schema_dump():
+def test_python_version_schema_dump():
     data = PythonVersionSchema().dump(VERSION)
     assert data == VERSION_BODY
 
 
-def test_version_schema_load_invalid():
+def test_python_version_schema_load_invalid():
     with pytest.raises(ValidationError):
-        PythonVersionSchema().load(INVALID_VERSION_BODY)
+        PythonVersionSchema().load(INVALID_PYTHON_VERSION_BODY)
 
 
-def test_version_schema_dump_invalid():
+def test_python_version_schema_dump_invalid():
     with pytest.raises(ValidationError):
-        PythonVersionSchema().dump(INVALID_VERSION)
+        PythonVersionSchema().dump(INVALID_PYTHON_VERSION)
 
+
+def test_apt_version_schema_load():
+    data = AptVersionSchema().load(VERSION_BODY)
+    assert data == VERSION
+
+
+def test_apt_version_schema_dump():
+    data = AptVersionSchema().dump(VERSION)
+    assert data == VERSION_BODY
+
+
+def test_apt_version_schema_load_invalid():
+    with pytest.raises(ValidationError):
+        AptVersionSchema().load(INVALID_APT_VERSION_BODY)
+
+
+def test_apt_version_schema_dump_invalid():
+    with pytest.raises(ValidationError):
+        AptVersionSchema().dump(INVALID_APT_VERSION)
 
 @pytest.mark.parametrize(
     "body, expected",

--- a/tests/clients/test_environment.py
+++ b/tests/clients/test_environment.py
@@ -57,14 +57,15 @@ VERSION = Version(constraint=Constraint.EQUAL, identifier="1.0.0")
 VERSION_BODY_LATEST = "latest"
 VERSION_LATEST = "latest"
 
-INVALID_PYTHON_VERSION_BODY = {"constraint": "==", "identifier": "invalid-identifier"}
+INVALID_PYTHON_VERSION_BODY = {
+    "constraint": "==",
+    "identifier": "invalid-identifier",
+}
 INVALID_PYTHON_VERSION = Version(
     constraint=Constraint.EQUAL, identifier="invalid-identifier"
 )
 INVALID_APT_VERSION_BODY = {"constraint": "==", "identifier": "    "}
-INVALID_APT_VERSION = Version(
-    constraint=Constraint.EQUAL, identifier="    "
-)
+INVALID_APT_VERSION = Version(constraint=Constraint.EQUAL, identifier="    ")
 
 PYTHON_PACKAGE_BODY = {"name": "tensorflow", "version": VERSION_BODY}
 PYTHON_PACKAGE = PythonPackage(name="tensorflow", version=VERSION)
@@ -230,6 +231,7 @@ def test_apt_version_schema_load_invalid():
 def test_apt_version_schema_dump_invalid():
     with pytest.raises(ValidationError):
         AptVersionSchema().dump(INVALID_APT_VERSION)
+
 
 @pytest.mark.parametrize(
     "body, expected",

--- a/tests/clients/test_environment.py
+++ b/tests/clients/test_environment.py
@@ -47,7 +47,7 @@ from faculty.clients.environment import (
     Specification,
     SpecificationSchema,
     Version,
-    VersionSchema,
+    PythonVersionSchema,
 )
 
 VERSION_BODY = {"constraint": "==", "identifier": "1.0.0"}
@@ -188,23 +188,23 @@ ENVIRONMENT_CREATE_UPDATE_NO_DESCRIPTION = EnvironmentCreateUpdate(
 
 
 def test_version_schema_load():
-    data = VersionSchema().load(VERSION_BODY)
+    data = PythonVersionSchema().load(VERSION_BODY)
     assert data == VERSION
 
 
 def test_version_schema_dump():
-    data = VersionSchema().dump(VERSION)
+    data = PythonVersionSchema().dump(VERSION)
     assert data == VERSION_BODY
 
 
 def test_version_schema_load_invalid():
     with pytest.raises(ValidationError):
-        VersionSchema().load(INVALID_VERSION_BODY)
+        PythonVersionSchema().load(INVALID_VERSION_BODY)
 
 
 def test_version_schema_dump_invalid():
     with pytest.raises(ValidationError):
-        VersionSchema().dump(INVALID_VERSION)
+        PythonVersionSchema().dump(INVALID_VERSION)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Currently, any attempt to include apt packages in the environment specification fails. This is because the client specifies packages as:

```json
{ "name": "..." }
```

whereas Baskerville wants:

```json
{ "name": "...", "version": "VERSION_IDENTIFIER" }
```

where `VERSION_IDENTIFIER` is `"latest" | {"constraint": "==", "identifier": "1.2.3" }`.

For a minimal example:

```py
import faculty
import os

ENVIRONMENT_SPECIFICATION = {
    "apt": {
        "packages": [
            {"name": "tree", "version": "latest"},
        ]
    },
    "python": {
        "python2": {
            "conda": {"packages": [], "channels": []},
            "pip": {"packages": [], "extra_index_urls": []}
        },
        "python3": {
            "conda": {"packages": [], "channels": []},
            "pip": {"packages": [], "extra_index_urls": []}
        }
    },
    "bash": {
        "script": "echo hello"
    }
}

c = faculty.client("environment")
c.create(os.environ["FACULTY_PROJECT_ID"], "test-544", ENVIRONMENT_SPECIFICATION, description="hello")
```