### PR TITLE
Handle the case where the dir ends with a slash

### DIFF
--- a/faculty/datasets/__init__.py
+++ b/faculty/datasets/__init__.py
@@ -435,7 +435,7 @@ def rmdir(project_path, project_id=None, object_client=None):
 
     rationalised_path = util.rationalise_path(project_path)
     project_path_as_file = rationalised_path.rstrip("/")
-    project_path_as_dir = rationalised_path + "/"
+    project_path_as_dir = project_path_as_file + "/"
 
     if contents == [project_path_as_dir]:
         rm(

--- a/tests/datasets/test_init.py
+++ b/tests/datasets/test_init.py
@@ -339,17 +339,18 @@ def test_rm(mocker, mock_client):
     )
 
 
-@pytest.mark.parametrize("prefix", ["", "/"])
-def test_rmdir(mocker, prefix):
+@pytest.mark.parametrize("prefix,suffix", [("", ""), ("/", ""), ("/", "/")])
+def test_rmdir(mocker, prefix, suffix):
+    project_path = prefix + "project-path" + suffix
     ls_mock = mocker.patch(
         "faculty.datasets.ls", return_value=["/project-path/"]
     )
     rm_mock = mocker.patch("faculty.datasets.rm")
 
-    datasets.rmdir(prefix + "project-path", project_id=PROJECT_ID)
+    datasets.rmdir(project_path, project_id=PROJECT_ID)
 
     ls_mock.assert_called_once_with(
-        prefix=prefix + "project-path",
+        prefix=project_path,
         project_id=PROJECT_ID,
         show_hidden=True,
         object_client=None,


### PR DESCRIPTION
`rmdir` allows for the case where the dir is specified with a trailing slash. We currently don't allow this. 

This PR changes it to allow that and adds a test case for it too 