### PR TITLE
Compress multipart upload request

### DIFF
--- a/faculty/clients/object.py
+++ b/faculty/clients/object.py
@@ -15,6 +15,8 @@
 
 from collections import namedtuple
 from enum import Enum
+import json
+import gzip
 
 from marshmallow import fields, post_load
 from marshmallow_enum import EnumField
@@ -422,4 +424,15 @@ class ObjectClient(BaseClient):
         body = schema.dump(
             {"path": path, "upload_id": upload_id, "parts": completed_parts}
         )
-        self._put_raw(endpoint, json=body)
+
+        json_body = json.dumps(body, separators=(",", ":"))
+        compressed_json_body = gzip.compress(json_body.encode("utf8"))
+
+        self._put_raw(
+            endpoint,
+            data=compressed_json_body,
+            headers={
+                "Content-Type": "application/json",
+                "Content-Encoding": "gzip",
+            },
+        )


### PR DESCRIPTION
This is a low-effort solution to help the request get through proxies with a low max body size.

In addition, we'll increase the max body size for this service on platform deployments.