### PR TITLE
Url encode object paths

### DIFF
--- a/faculty/clients/object.py
+++ b/faculty/clients/object.py
@@ -246,7 +246,7 @@ class ObjectClient(BaseClient):
         SourceIsADirectory
             When the source path to copy is a directory but recursive is false
         """
-        
+
         url_encoded_destination = urllib.parse.quote(destination.lstrip("/"))
 
         endpoint = "/project/{}/object/{}".format(

--- a/faculty/clients/object.py
+++ b/faculty/clients/object.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import urllib
-
 from collections import namedtuple
 from enum import Enum
+from six.moves import urllib
 
 from marshmallow import fields, post_load
 from marshmallow_enum import EnumField

--- a/faculty/clients/object.py
+++ b/faculty/clients/object.py
@@ -148,7 +148,10 @@ class ObjectClient(BaseClient):
         -------
         Object
         """
-        endpoint = "/project/{}/object/{}".format(project_id, path.lstrip("/"))
+
+        url_encoded_path = urllib.parse.quote(path.lstrip("/"))
+
+        endpoint = "/project/{}/object/{}".format(project_id, url_encoded_path)
         return self._get(endpoint, ObjectSchema())
 
     def list(self, project_id, prefix="/", page_token=None):
@@ -207,8 +210,10 @@ class ObjectClient(BaseClient):
         PathAlreadyExists
             when the path that we want to create as a directory already exists
         """
+        url_encoded_path = urllib.parse.quote(path.lstrip("/"))
+
         endpoint = "/project/{}/directory/{}".format(
-            project_id, path.lstrip("/")
+            project_id, url_encoded_path
         )
         params = {"parents": 1 if parents else 0}
         try:
@@ -241,8 +246,11 @@ class ObjectClient(BaseClient):
         SourceIsADirectory
             When the source path to copy is a directory but recursive is false
         """
+        
+        url_encoded_destination = urllib.parse.quote(destination.lstrip("/"))
+
         endpoint = "/project/{}/object/{}".format(
-            project_id, destination.lstrip("/")
+            project_id, url_encoded_destination
         )
         params = {"sourcePath": source}
         if recursive is not None:
@@ -280,7 +288,8 @@ class ObjectClient(BaseClient):
         TargetIsADirectory
             When the target to delete is a directory but recursive is false
         """
-        endpoint = "/project/{}/object/{}".format(project_id, path.lstrip("/"))
+        url_encoded_path = urllib.parse.quote(path.lstrip("/"))
+        endpoint = "/project/{}/object/{}".format(project_id, url_encoded_path)
         params = {}
         if recursive is not None:
             params["recursive"] = 1 if recursive else 0

--- a/faculty/clients/object.py
+++ b/faculty/clients/object.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import urllib
 
 from collections import namedtuple
 from enum import Enum
@@ -178,8 +179,10 @@ class ObjectClient(BaseClient):
             Containing a list of matching objects and a token to get the next
             page of objects, when relevant.
         """
+        url_encoded_prefix = urllib.parse.quote(prefix.lstrip("/"))
+
         endpoint = "/project/{}/object-list/{}".format(
-            project_id, prefix.lstrip("/")
+            project_id, url_encoded_prefix
         )
         params = {}
         if page_token is not None:

--- a/tests/clients/test_object.py
+++ b/tests/clients/test_object.py
@@ -189,7 +189,7 @@ def test_object_client_get(mocker, path):
     )
 
 
-@pytest.mark.parametrize("path", ["test/path", "/test/path", "//test/path"])
+@pytest.mark.parametrize("path", ["test/path", "/test/path", "//test/path",])
 def test_object_client_list(mocker, path):
     mocker.patch.object(
         ObjectClient, "_get", return_value=LIST_OBJECTS_RESPONSE
@@ -227,6 +227,28 @@ def test_object_client_list_defaults(mocker):
         "/project/{}/object-list/".format(PROJECT_ID),
         schema_mock.return_value,
         params={},
+    )
+
+
+def test_object_client_list_url_encoding(mocker):
+    path = "/test [1]/"
+    mocker.patch.object(
+        ObjectClient, "_get", return_value=LIST_OBJECTS_RESPONSE
+    )
+    schema_mock = mocker.patch(
+        "faculty.clients.object.ListObjectsResponseSchema"
+    )
+
+    client = ObjectClient(mocker.Mock())
+
+    response = client.list(PROJECT_ID, path, page_token="token")
+    assert response == LIST_OBJECTS_RESPONSE
+
+    schema_mock.assert_called_once_with()
+    ObjectClient._get.assert_called_once_with(
+        "/project/{}/object-list/test%20%5B1%5D/".format(PROJECT_ID),
+        schema_mock.return_value,
+        params={"pageToken": "token"},
     )
 
 

--- a/tests/clients/test_object.py
+++ b/tests/clients/test_object.py
@@ -189,6 +189,21 @@ def test_object_client_get(mocker, path):
     )
 
 
+def test_object_client_get_url_encoding(mocker):
+    path = "/test/[1].txt"
+    mocker.patch.object(ObjectClient, "_get", return_value=OBJECT)
+    schema_mock = mocker.patch("faculty.clients.object.ObjectSchema")
+
+    client = ObjectClient(mocker.Mock())
+    assert client.get(PROJECT_ID, path) == OBJECT
+
+    schema_mock.assert_called_once_with()
+    ObjectClient._get.assert_called_once_with(
+        "/project/{}/object/test/%5B1%5D.txt".format(PROJECT_ID),
+        schema_mock.return_value,
+    )
+
+
 @pytest.mark.parametrize("path", ["test/path", "/test/path", "//test/path",])
 def test_object_client_list(mocker, path):
     mocker.patch.object(
@@ -277,6 +292,18 @@ def test_object_client_create_directory(mocker, parents, expected_parent):
     )
 
 
+def test_object_client_create_directory_url_encoding(mocker):
+    mocker.patch.object(ObjectClient, "_put_raw")
+
+    client = ObjectClient(mocker.Mock())
+    client.create_directory(PROJECT_ID, "[1]")
+
+    ObjectClient._put_raw.assert_called_once_with(
+        "/project/{}/directory/%5B1%5D".format(PROJECT_ID),
+        params={"parents": 0},
+    )
+
+
 def test_object_client_create_directory_already_exists(mocker):
     error_code = "object_already_exists"
     exception = Conflict(mocker.Mock(), mocker.Mock(), error_code)
@@ -300,6 +327,18 @@ def test_object_client_copy_default(mocker):
 
     ObjectClient._put_raw.assert_called_once_with(
         "/project/{}/object/{}".format(PROJECT_ID, "destination"),
+        params={"sourcePath": "source", "recursive": 0},
+    )
+
+
+def test_object_client_copy_url_encoding(mocker):
+    mocker.patch.object(ObjectClient, "_put_raw")
+
+    client = ObjectClient(mocker.Mock())
+    client.copy(PROJECT_ID, "source", "/[1]/")
+
+    ObjectClient._put_raw.assert_called_once_with(
+        "/project/{}/object/%5B1%5D/".format(PROJECT_ID,),
         params={"sourcePath": "source", "recursive": 0},
     )
 
@@ -348,6 +387,19 @@ def test_object_client_delete_default(mocker):
 
     ObjectClient._delete_raw.assert_called_once_with(
         "/project/{}/object/{}".format(PROJECT_ID, path),
+        params={"recursive": 0},
+    )
+
+
+def test_object_client_delete_url_encoding(mocker):
+    path = "[1]"
+    mocker.patch.object(ObjectClient, "_delete_raw")
+
+    client = ObjectClient(mocker.Mock())
+    client.delete(PROJECT_ID, path)
+
+    ObjectClient._delete_raw.assert_called_once_with(
+        "/project/{}/object/%5B1%5D".format(PROJECT_ID),
         params={"recursive": 0},
     )
 

--- a/tests/clients/test_object.py
+++ b/tests/clients/test_object.py
@@ -204,7 +204,7 @@ def test_object_client_get_url_encoding(mocker):
     )
 
 
-@pytest.mark.parametrize("path", ["test/path", "/test/path", "//test/path",])
+@pytest.mark.parametrize("path", ["test/path", "/test/path", "//test/path"])
 def test_object_client_list(mocker, path):
     mocker.patch.object(
         ObjectClient, "_get", return_value=LIST_OBJECTS_RESPONSE
@@ -338,7 +338,7 @@ def test_object_client_copy_url_encoding(mocker):
     client.copy(PROJECT_ID, "source", "/[1]/")
 
     ObjectClient._put_raw.assert_called_once_with(
-        "/project/{}/object/%5B1%5D/".format(PROJECT_ID,),
+        "/project/{}/object/%5B1%5D/".format(PROJECT_ID),
         params={"sourcePath": "source", "recursive": 0},
     )
 


### PR DESCRIPTION
This addresses a bug Liam noticed in datasets where path string are placed directly in url's unencoded