### PR TITLE
Fix environment model

### DIFF
--- a/faculty/clients/environment.py
+++ b/faculty/clients/environment.py
@@ -233,7 +233,7 @@ class EnvironmentSchema(BaseSchema):
     id = fields.UUID(data_key="environmentId", required=True)
     project_id = fields.UUID(data_key="projectId", required=True)
     name = fields.String(required=True)
-    description = fields.String(required=True)
+    description = fields.String(required=True, allow_none=True)
     author_id = fields.UUID(data_key="authorId", required=True)
     created_at = fields.DateTime(data_key="createdAt", required=True)
     updated_at = fields.DateTime(data_key="updatedAt", required=True)

--- a/faculty/clients/environment.py
+++ b/faculty/clients/environment.py
@@ -233,7 +233,7 @@ class EnvironmentSchema(BaseSchema):
     id = fields.UUID(data_key="environmentId", required=True)
     project_id = fields.UUID(data_key="projectId", required=True)
     name = fields.String(required=True)
-    description = fields.String(required=True, allow_none=True)
+    description = fields.String(missing=None)
     author_id = fields.UUID(data_key="authorId", required=True)
     created_at = fields.DateTime(data_key="createdAt", required=True)
     updated_at = fields.DateTime(data_key="updatedAt", required=True)
@@ -246,7 +246,7 @@ class EnvironmentSchema(BaseSchema):
 
 class EnvironmentCreateUpdateSchema(BaseSchema):
     name = fields.String(required=True)
-    description = fields.String(required=True, allow_none=True)
+    description = fields.String(missing=None)
     specification = fields.Nested(SpecificationSchema(), required=True)
 
     @post_load

--- a/tests/clients/test_environment.py
+++ b/tests/clients/test_environment.py
@@ -172,6 +172,27 @@ ENVIRONMENT = Environment(
     specification=SPECIFICATION,
 )
 
+ENVIRONMENT_BODY_NO_DESCRIPTION = {
+    "environmentId": str(ENVIRONMENT_ID),
+    "projectId": str(PROJECT_ID),
+    "name": NAME,
+    "description": None,
+    "authorId": str(AUTHOR_ID),
+    "createdAt": "2018-10-03T04:20:00Z",
+    "updatedAt": "2018-11-03T04:21:15Z",
+    "specification": SPECIFICATION_BODY,
+}
+ENVIRONMENT_NO_DESCRIPTION = Environment(
+    id=ENVIRONMENT_ID,
+    project_id=PROJECT_ID,
+    name=NAME,
+    description=None,
+    author_id=AUTHOR_ID,
+    created_at=datetime.datetime(2018, 10, 3, 4, 20, 0, 0, tzinfo=UTC),
+    updated_at=datetime.datetime(2018, 11, 3, 4, 21, 15, 0, tzinfo=UTC),
+    specification=SPECIFICATION,
+)
+
 ENVIRONMENT_CREATION_RESPONSE_BODY = {"environmentId": str(ENVIRONMENT_ID)}
 ENVIRONMENT_CREATION_RESPONSE = EnvironmentCreationResponse(id=ENVIRONMENT_ID)
 
@@ -407,6 +428,11 @@ def test_environment_creation_response_schema():
 def test_environment_schema():
     data = EnvironmentSchema().load(ENVIRONMENT_BODY)
     assert data == ENVIRONMENT
+
+
+def test_environment_schema_no_description():
+    data = EnvironmentSchema().load(ENVIRONMENT_BODY_NO_DESCRIPTION)
+    assert data == ENVIRONMENT_NO_DESCRIPTION
 
 
 def test_environment_schema_invalid():


### PR DESCRIPTION
Currently if you list environments for a project and one of them has an empty description the command fails with:
`marshmallow.exceptions.ValidationError: {1: {'description': ['Field may not be null.']}}`

This is incorrect as the description for an environment can be None (see EnvironmentCreateUpdateSchema).  This PR fixes this and adds a test to prevent regression. I've also tested it successfully against one of the dev clusters