### PR TITLE
Pin test dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py27, py34, py35, py36, py37, flake8, black, license
 sitepackages = False
 deps =
     pytest
-    pytest-mock
+    pytest-mock<1.12
     requests_mock
     python-dateutil>=2.7
 commands = pytest {posargs}


### PR DESCRIPTION
There appears to be an issue with pytest-mock version 1.12. Going to pin for now.