### PR TITLE
Make arguments to faculty.client explicit and add docstring

### DIFF
--- a/faculty/__init__.py
+++ b/faculty/__init__.py
@@ -75,9 +75,9 @@ def client(
     ... )
     <faculty.clients.account.AccountClient object at 0x10e447550>
 
-    To override any of the domain, protocol, client ID or client secret read
-    from a credentials file or from environment variables, pass their
-    respective arguments:
+    To set any of the domain, protocol, client ID or client secret, pass their
+    respective arguments. These always take higher precendence than values read
+    from configuration files or environment variables:
 
     >>> faculty.client(
     ...     "account",

--- a/faculty/__init__.py
+++ b/faculty/__init__.py
@@ -17,7 +17,24 @@ import faculty.session
 import faculty.clients
 
 
-def client(resource, **kwargs):
-    session = faculty.session.get_session(**kwargs)
+def client(
+    resource,
+    credentials_path=None,
+    profile_name=None,
+    domain=None,
+    protocol=None,
+    client_id=None,
+    client_secret=None,
+    access_token_cache=None,
+):
+    session = faculty.session.get_session(
+        credentials_path=credentials_path,
+        profile_name=profile_name,
+        domain=domain,
+        protocol=protocol,
+        client_id=client_id,
+        client_secret=client_secret,
+        access_token_cache=access_token_cache,
+    )
     client_class = faculty.clients.for_resource(resource)
     return client_class(session)

--- a/faculty/__init__.py
+++ b/faculty/__init__.py
@@ -27,6 +27,67 @@ def client(
     client_secret=None,
     access_token_cache=None,
 ):
+    """
+    Construct a client for a Faculty resource.
+
+    Parameters
+    ----------
+    resource : str
+        The resource to construct a client for.
+    credentials_path : str or pathlib.Path, optional
+        The path of a file to load Faculty credentials from.
+    profile_name : str, optional
+        The name of the profile to read from the credentials file. The default
+        is 'default'.
+    domain : str, optional
+        The domain to access Faculty services at. This is provided when you
+        generate credentials in the platform.
+    protocol : str, optional
+        Either 'http' or 'https' (the default).
+    client_id : str, optional
+        The Faculty client ID to user. This is provided when you generate
+        credentials in the platform.
+    client_secret : str, optional
+        The Faculty client secret to use. This is provided when you generate
+        credentials in the platform.
+    access_token_cache : faculty.session.accesstoken.AccessTokenMemoryCache or
+    faculty.session.accesstoken.AccessTokenMemoryCache, optional
+        Set the access token cache used. The default is an
+        AccessTokenMemoryCache.
+
+    Examples
+    --------
+    To construct a client loading default configuration and credentials (from
+    ~/.config/faculty/credentials or from environment variables), simply call
+    this function with the resource type as a string:
+
+    >>> faculty.client("account")
+    <faculty.clients.account.AccountClient object at 0x10d4b7fd0>
+
+    To load a different configuration file, or load a profile from the file
+    other than 'default', pass the `credentials_path` or `profile_name`
+    arguments respectively:
+
+    >>> faculty.client(
+    ...     "account",
+    ...     credentials_path="other/credentials",
+    ...     profile_name="custom",
+    ... )
+    <faculty.clients.account.AccountClient object at 0x10e447550>
+
+    To override any of the domain, protocol, client ID or client secret read
+    from a credentials file or from environment variables, pass their
+    respective arguments:
+
+    >>> faculty.client(
+    ...     "account",
+    ...     domain="services.faculty.myorganisation.com",
+    ...     protocol="http",
+    ...     client_id="d047dad1-175b-4810-84b1-c0ff6bbcf456",
+    ...     client_secret="Vk4a1FgSKlTplkK0GkToAdRTdsoU4XHuwCMQ",
+    ... )
+    <faculty.clients.account.AccountClient object at 0x10e4472b0>
+    """
     session = faculty.session.get_session(
         credentials_path=credentials_path,
         profile_name=profile_name,

--- a/faculty/session/__init__.py
+++ b/faculty/session/__init__.py
@@ -68,12 +68,35 @@ class Session(object):
 _SESSION_CACHE = {}
 
 
-def get_session(access_token_cache=None, **kwargs):
-    key = tuple(kwargs.items()) + (access_token_cache,)
+def get_session(
+    access_token_cache=None,
+    credentials_path=None,
+    profile_name=None,
+    domain=None,
+    protocol=None,
+    client_id=None,
+    client_secret=None,
+):
+    key = (
+        access_token_cache,
+        credentials_path,
+        profile_name,
+        domain,
+        protocol,
+        client_id,
+        client_secret,
+    )
     try:
         session = _SESSION_CACHE[key]
     except KeyError:
-        profile = faculty.config.resolve_profile(**kwargs)
+        profile = faculty.config.resolve_profile(
+            credentials_path=credentials_path,
+            profile_name=profile_name,
+            domain=domain,
+            protocol=protocol,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
         access_token_cache = access_token_cache or AccessTokenMemoryCache()
         session = Session(profile, access_token_cache)
         _SESSION_CACHE[key] = session

--- a/tests/session/test_init.py
+++ b/tests/session/test_init.py
@@ -106,13 +106,20 @@ def test_get_session(mocker, isolated_session_cache):
     access_token_cache = mocker.Mock()
     mocker.spy(Session, "__init__")
 
+    config_kwargs = {
+        "credentials_path": "/path/to/credentials",
+        "profile_name": "my-profile",
+        "domain": "domain.com",
+        "protocol": "http",
+        "client_id": "client-id",
+        "client_secret": "client-secret",
+    }
+
     session = get_session(
-        kwarg1="foo", kwarg2="bar", access_token_cache=access_token_cache
+        access_token_cache=access_token_cache, **config_kwargs
     )
 
-    faculty.config.resolve_profile.assert_called_once_with(
-        kwarg1="foo", kwarg2="bar"
-    )
+    faculty.config.resolve_profile.assert_called_once_with(**config_kwargs)
     Session.__init__.assert_called_once_with(
         session, PROFILE, access_token_cache
     )
@@ -129,7 +136,14 @@ def test_get_session_defaults(mocker, isolated_session_cache):
 
     session = get_session()
 
-    faculty.config.resolve_profile.assert_called_once_with()
+    faculty.config.resolve_profile.assert_called_once_with(
+        credentials_path=None,
+        profile_name=None,
+        domain=None,
+        protocol=None,
+        client_id=None,
+        client_secret=None,
+    )
     Session.__init__.assert_called_once_with(
         session, PROFILE, access_token_cache
     )
@@ -140,8 +154,12 @@ def test_get_session_cache(mocker, isolated_session_cache):
     access_token_cache = mocker.Mock()
     mocker.spy(Session, "__init__")
 
-    session1 = get_session(kwarg="foo", access_token_cache=access_token_cache)
-    session2 = get_session(kwarg="foo", access_token_cache=access_token_cache)
+    session1 = get_session(
+        access_token_cache=access_token_cache, profile_name="profile"
+    )
+    session2 = get_session(
+        access_token_cache=access_token_cache, profile_name="profile"
+    )
 
     assert session1 is session2
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,10 +20,41 @@ def test_client(mocker):
     get_session_mock = mocker.patch("faculty.session.get_session")
     for_resource_mock = mocker.patch("faculty.clients.for_resource")
 
-    options = {"foo": "bar"}
+    options = {
+        "credentials_path": "/path/to/credentials",
+        "profile_name": "my-profile",
+        "domain": "domain.com",
+        "protocol": "http",
+        "client_id": "client-id",
+        "client_secret": "client-secret",
+        "access_token_cache": mocker.Mock(),
+    }
+
     faculty.client("test-resource", **options)
 
     get_session_mock.assert_called_once_with(**options)
+    for_resource_mock.assert_called_once_with("test-resource")
+
+    returned_session = get_session_mock.return_value
+    returned_class = for_resource_mock.return_value
+    returned_class.assert_called_once_with(returned_session)
+
+
+def test_client_defaults(mocker):
+    get_session_mock = mocker.patch("faculty.session.get_session")
+    for_resource_mock = mocker.patch("faculty.clients.for_resource")
+
+    faculty.client("test-resource")
+
+    get_session_mock.assert_called_once_with(
+        credentials_path=None,
+        profile_name=None,
+        domain=None,
+        protocol=None,
+        client_id=None,
+        client_secret=None,
+        access_token_cache=None,
+    )
     for_resource_mock.assert_called_once_with("test-resource")
 
     returned_session = get_session_mock.return_value


### PR DESCRIPTION
It's currently hard to understand which arguments you can pass to `faculty.client`. This PR makes them explicit instead of relying on `**kwargs` and adds a docstring.