### PR TITLE
Make `datasets.mv` do nothing if source and destination are the same

### DIFF
--- a/faculty/datasets/__init__.py
+++ b/faculty/datasets/__init__.py
@@ -334,6 +334,9 @@ def mv(source_path, destination_path, project_id=None, object_client=None):
     project_id = project_id or get_context().project_id
     object_client = object_client or ObjectClient(get_session())
 
+    if source_path == destination_path:
+        return
+
     cp(
         source_path,
         destination_path,

--- a/tests/datasets/test_init.py
+++ b/tests/datasets/test_init.py
@@ -439,6 +439,16 @@ def test_mv(mocker, mock_client):
     )
 
 
+def test_mv_identical_source_and_destination(mocker, mock_client):
+    cp_mock = mocker.patch("faculty.datasets.cp")
+    rm_mock = mocker.patch("faculty.datasets.rm")
+
+    datasets.mv("source-path", "source-path", project_id=PROJECT_ID)
+
+    cp_mock.assert_not_called()
+    rm_mock.assert_not_called()
+
+
 def test_etag(mocker, mock_client):
     object_mock = mocker.Mock()
     object_mock.etag = "test-etag"


### PR DESCRIPTION
Make `datasets.mv` do nothing if source and destination are the same. 

Because `mv` is implemented as `cp` then `rm`, the previous behaviour was to delete the file if the source and destination are the same. The new behaviour is to do nothing (like the Unix `mv` command). 