### PR TITLE
Publish new template

### DIFF
--- a/faculty/clients/__init__.py
+++ b/faculty/clients/__init__.py
@@ -17,6 +17,7 @@ from faculty.clients.account import AccountClient
 from faculty.clients.cluster import ClusterClient
 from faculty.clients.environment import EnvironmentClient
 from faculty.clients.experiment import ExperimentClient
+from faculty.clients.notification import NotificationClient
 from faculty.clients.job import JobClient
 from faculty.clients.log import LogClient
 from faculty.clients.model import ModelClient
@@ -25,6 +26,7 @@ from faculty.clients.project import ProjectClient
 from faculty.clients.report import ReportClient
 from faculty.clients.secret import SecretClient
 from faculty.clients.server import ServerClient
+from faculty.clients.template import TemplateClient
 from faculty.clients.user import UserClient
 from faculty.clients.workspace import WorkspaceClient
 
@@ -34,6 +36,7 @@ CLIENT_FOR_RESOURCE = {
     "cluster": ClusterClient,
     "environment": EnvironmentClient,
     "experiment": ExperimentClient,
+    "notification": NotificationClient,
     "job": JobClient,
     "log": LogClient,
     "model": ModelClient,
@@ -42,6 +45,7 @@ CLIENT_FOR_RESOURCE = {
     "report": ReportClient,
     "secret": SecretClient,
     "server": ServerClient,
+    "template": TemplateClient,
     "user": UserClient,
     "workspace": WorkspaceClient,
 }

--- a/faculty/clients/notification.py
+++ b/faculty/clients/notification.py
@@ -1,0 +1,102 @@
+# Copyright 2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Consume notifications from the Faculty frontend.
+"""
+
+import json
+
+import sseclient
+
+from faculty.clients.base import BaseClient
+
+
+class NotificationClient(BaseClient):
+    """Client to listen on notifications from the Faculty frontend.
+
+    Either build this client with a session directly, or use the
+    :func:`faculty.client` helper function:
+
+    >>> client = faculty.client("notification")
+
+    Parameters
+    ----------
+    session : faculty.session.Session
+        The session to use to make requests
+    """
+
+    _SERVICE_NAME = "frontend"
+
+    def user_updates(self, user_id):
+        """Get notification events for the given user.
+
+        Parameters
+        ----------
+        user_id : uuid.UUID
+            ID of the user to get updates for.
+
+        Returns
+        -------
+        generator
+            Server-sent events
+        """
+        endpoint = "api/updates/user/{}".format(user_id)
+        response = self._get_raw(endpoint, stream=True)
+        client = sseclient.SSEClient(response)
+        return client.events()
+
+    def check_publish_template_result(self, events, project_id):
+        """Handle results of a template publishing operation.
+
+        Only returns when success or failure events are received for the given
+        source project_id. Events with other project IDs are ignored.
+
+        Parameters
+        ----------
+        project_id : uuid.UUID
+            The project from which the template was published.
+        events : generator
+            The value that was returned from
+            :func:`faculty.clients.notification.NotificationClient.user_updates`
+        """
+        for e in events:
+            body = json.loads(e.data)
+            if body.get("sourceProjectId") == str(project_id):
+                if e.event == "@SSE/PROJECT_TEMPLATE_PUBLISH_NEW_FAILED":
+                    msg = _extract_publishing_error_msg(body)
+                    raise TemplatePublishingError(msg)
+                elif e.event == "@SSE/PROJECT_TEMPLATE_PUBLISH_NEW_COMPLETED":
+                    return
+
+
+def _extract_publishing_error_msg(error_body):
+    try:
+        code = error_body["errorCode"]
+        if code in {"name_conflict", "unexpected_error"}:
+            return error_body["error"]
+        elif code == "template_rendering_error":
+            errors = error_body["errors"]
+            msg = "Failed to render the template with default parameters:"
+            for e in errors:
+                msg += "\n\t{} in file {}".format(e["error"], e["path"])
+            return msg
+        else:
+            return "Unexpected error code received"
+    except KeyError:
+        return "Unexpected server response"
+
+
+class TemplatePublishingError(Exception):
+    pass

--- a/faculty/clients/notification.py
+++ b/faculty/clients/notification.py
@@ -70,6 +70,7 @@ class NotificationClient(BaseClient):
         source_project_id : uuid.UUID
             The project from which the template was published.
         """
+
         def is_publishing_event(event):
             if not event.event.startswith("@SSE/PROJECT_TEMPLATE_PUBLISH"):
                 return False

--- a/faculty/clients/notification.py
+++ b/faculty/clients/notification.py
@@ -57,7 +57,7 @@ class NotificationClient(BaseClient):
         client = sseclient.SSEClient(response)
         return client.events()
 
-    def check_publish_template_result(self, events, project_id):
+    def check_publish_template_result(self, project_id, events):
         """Handle results of a template publishing operation.
 
         Only returns when success or failure events are received for the given

--- a/faculty/clients/template.py
+++ b/faculty/clients/template.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Interact with the Faculty knowledge centre templates.
+"""
+
+from faculty.clients.base import BaseClient
+
+
+class TemplateClient(BaseClient):
+    """Client for the the Knowledge centre templates.
+
+    Either build this client with a session directly, or use the
+    :func:`faculty.client` helper function:
+
+    >>> client = faculty.client("template")
+
+    Parameters
+    ----------
+    session : faculty.session.Session
+        The session to use to make requests
+    """
+
+    _SERVICE_NAME = "kanto"
+
+    def publish_new(self, template, source_directory, project_id):
+        endpoint = "template"
+        payload = {
+            "sourceProjectId": str(project_id),
+            "sourceDirectory": source_directory,
+            "name": template,
+        }
+        return self._post_raw(endpoint, json=payload)

--- a/faculty/clients/template.py
+++ b/faculty/clients/template.py
@@ -35,7 +35,7 @@ class TemplateClient(BaseClient):
 
     _SERVICE_NAME = "kanto"
 
-    def publish_new(self, template, source_directory, project_id):
+    def publish_new(self, project_id, template, source_directory):
         endpoint = "template"
         payload = {
             "sourceProjectId": str(project_id),

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "attrs",
         "marshmallow[reco]==3.0.0rc3",
         "marshmallow_enum",
+        "sseclient-py",
     ],
     dependency_links=[
         "git+https://github.com/marshmallow-code/marshmallow"

--- a/tests/clients/test_model.py
+++ b/tests/clients/test_model.py
@@ -134,8 +134,7 @@ def test_model_client_list(mocker):
 
     schema_mock.assert_called_once_with(many=True)
     ModelClient._get.assert_called_once_with(
-        "/project/{}/model".format(PROJECT_ID, MODEL_ID),
-        schema_mock.return_value,
+        "/project/{}/model".format(PROJECT_ID), schema_mock.return_value
     )
 
 

--- a/tests/clients/test_notification.py
+++ b/tests/clients/test_notification.py
@@ -59,7 +59,7 @@ def test_check_publish_template_result_success(mocker):
         )
 
     client = NotificationClient(mocker.Mock())
-    client.check_publish_template_result(events(), PROJECT_ID)
+    client.check_publish_template_result(PROJECT_ID, events())
 
 
 def test_check_publish_template_result_other_project(mocker):
@@ -74,7 +74,7 @@ def test_check_publish_template_result_other_project(mocker):
         )
 
     client = NotificationClient(mocker.Mock())
-    client.check_publish_template_result(events(), PROJECT_ID)
+    client.check_publish_template_result(PROJECT_ID, events())
 
 
 @pytest.mark.parametrize("error_code", ["name_conflict", "unexpected_error"])
@@ -93,7 +93,7 @@ def test_check_publish_template_result_errors(mocker, error_code):
 
     client = NotificationClient(mocker.Mock())
     with pytest.raises(TemplatePublishingError, match="dummy error message"):
-        client.check_publish_template_result(events(), PROJECT_ID)
+        client.check_publish_template_result(PROJECT_ID, events())
 
 
 def test_check_publish_template_result_rendering_errors(mocker):
@@ -117,7 +117,7 @@ def test_check_publish_template_result_rendering_errors(mocker):
 \tUnexpected key { abc } in file a.py
 \tUnexpected key { abc } in file a/b.py"""
     with pytest.raises(TemplatePublishingError, match=expected_message):
-        client.check_publish_template_result(events(), PROJECT_ID)
+        client.check_publish_template_result(PROJECT_ID, events())
 
 
 def test_check_publish_template_result_rendering_unexpected_error_code(mocker):
@@ -136,7 +136,7 @@ def test_check_publish_template_result_rendering_unexpected_error_code(mocker):
     with pytest.raises(
         TemplatePublishingError, match="Unexpected error code received"
     ):
-        client.check_publish_template_result(events(), PROJECT_ID)
+        client.check_publish_template_result(PROJECT_ID, events())
 
 
 def test_check_publish_template_result_rendering_no_error_code(mocker):
@@ -150,4 +150,4 @@ def test_check_publish_template_result_rendering_no_error_code(mocker):
     with pytest.raises(
         TemplatePublishingError, match="Unexpected server response"
     ):
-        client.check_publish_template_result(events(), PROJECT_ID)
+        client.check_publish_template_result(PROJECT_ID, events())

--- a/tests/clients/test_notification.py
+++ b/tests/clients/test_notification.py
@@ -1,0 +1,153 @@
+# Copyright 2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+import uuid
+
+import pytest
+import sseclient
+from sseclient import Event
+
+from faculty.clients.notification import (
+    NotificationClient,
+    TemplatePublishingError,
+)
+
+
+PROJECT_ID = uuid.uuid4()
+USER_ID_STRING = "3024d586-6a4a-4fc1-98a9-c6135b163f17"
+USER_ID = uuid.UUID(USER_ID_STRING)
+
+
+def test_user_updates(mocker):
+    mock_response = mocker.Mock()
+    mocker.patch.object(
+        NotificationClient, "_get_raw", return_value=mock_response
+    )
+    mock_sse_client = mocker.Mock()
+    mock_events = mocker.Mock()
+    mock_sse_client.events = mocker.Mock(return_value=mock_events)
+    mocker.patch.object(sseclient, "SSEClient", return_value=mock_sse_client)
+
+    client = NotificationClient(mocker.Mock())
+    client.user_updates(USER_ID)
+
+    NotificationClient._get_raw.assert_called_once_with(
+        "api/updates/user/{}".format(USER_ID_STRING), stream=True
+    )
+    sseclient.SSEClient.assert_called_once_with(mock_response)
+    mock_sse_client.events.assert_called_once_with()
+
+
+def test_check_publish_template_result_success(mocker):
+    def events():
+        yield Event(
+            event="@SSE/PROJECT_TEMPLATE_PUBLISH_NEW_COMPLETED",
+            data=json.dumps({"sourceProjectId": str(PROJECT_ID)}),
+        )
+
+    client = NotificationClient(mocker.Mock())
+    client.check_publish_template_result(events(), PROJECT_ID)
+
+
+def test_check_publish_template_result_other_project(mocker):
+    def events():
+        yield Event(
+            event="@SSE/PROJECT_TEMPLATE_PUBLISH_NEW_FAILED",
+            data=json.dumps({"sourceProjectId": "other project ID"}),
+        )
+        yield Event(
+            event="@SSE/PROJECT_TEMPLATE_PUBLISH_NEW_COMPLETED",
+            data=json.dumps({"sourceProjectId": str(PROJECT_ID)}),
+        )
+
+    client = NotificationClient(mocker.Mock())
+    client.check_publish_template_result(events(), PROJECT_ID)
+
+
+@pytest.mark.parametrize("error_code", ["name_conflict", "unexpected_error"])
+def test_check_publish_template_result_errors(mocker, error_code):
+    def events():
+        yield Event(
+            event="@SSE/PROJECT_TEMPLATE_PUBLISH_NEW_FAILED",
+            data=json.dumps(
+                {
+                    "sourceProjectId": str(PROJECT_ID),
+                    "errorCode": error_code,
+                    "error": "dummy error message",
+                }
+            ),
+        )
+
+    client = NotificationClient(mocker.Mock())
+    with pytest.raises(TemplatePublishingError, match="dummy error message"):
+        client.check_publish_template_result(events(), PROJECT_ID)
+
+
+def test_check_publish_template_result_rendering_errors(mocker):
+    def events():
+        yield Event(
+            event="@SSE/PROJECT_TEMPLATE_PUBLISH_NEW_FAILED",
+            data=json.dumps(
+                {
+                    "sourceProjectId": str(PROJECT_ID),
+                    "errorCode": "template_rendering_error",
+                    "errors": [
+                        {"error": "Unexpected key { abc }", "path": "a.py"},
+                        {"error": "Unexpected key { abc }", "path": "a/b.py"},
+                    ],
+                }
+            ),
+        )
+
+    client = NotificationClient(mocker.Mock())
+    expected_message = """Failed to render the template with default parameters:
+\tUnexpected key { abc } in file a.py
+\tUnexpected key { abc } in file a/b.py"""
+    with pytest.raises(TemplatePublishingError, match=expected_message):
+        client.check_publish_template_result(events(), PROJECT_ID)
+
+
+def test_check_publish_template_result_rendering_unexpected_error_code(mocker):
+    def events():
+        yield Event(
+            event="@SSE/PROJECT_TEMPLATE_PUBLISH_NEW_FAILED",
+            data=json.dumps(
+                {
+                    "sourceProjectId": str(PROJECT_ID),
+                    "errorCode": "unkown erorr code",
+                }
+            ),
+        )
+
+    client = NotificationClient(mocker.Mock())
+    with pytest.raises(
+        TemplatePublishingError, match="Unexpected error code received"
+    ):
+        client.check_publish_template_result(events(), PROJECT_ID)
+
+
+def test_check_publish_template_result_rendering_no_error_code(mocker):
+    def events():
+        yield Event(
+            event="@SSE/PROJECT_TEMPLATE_PUBLISH_NEW_FAILED",
+            data=json.dumps({"sourceProjectId": str(PROJECT_ID)}),
+        )
+
+    client = NotificationClient(mocker.Mock())
+    with pytest.raises(
+        TemplatePublishingError, match="Unexpected server response"
+    ):
+        client.check_publish_template_result(events(), PROJECT_ID)

--- a/tests/clients/test_notification.py
+++ b/tests/clients/test_notification.py
@@ -184,6 +184,7 @@ def test_wait_for_completion_rendering_unexpected_error_code(mocker):
                 }
             ),
         )
+
     user_updates_mock = mocker.patch.object(
         NotificationClient, "user_updates", return_value=events()
     )

--- a/tests/clients/test_template.py
+++ b/tests/clients/test_template.py
@@ -1,0 +1,37 @@
+# Copyright 2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import uuid
+
+from faculty.clients.template import TemplateClient
+
+
+PROJECT_ID = uuid.uuid4()
+
+
+def test_publish_new(mocker):
+    mocker.patch.object(TemplateClient, "_post_raw")
+
+    client = TemplateClient(mocker.Mock())
+    client.publish_new("template name", "source/dir", PROJECT_ID)
+
+    TemplateClient._post_raw.assert_called_once_with(
+        "template",
+        json={
+            "sourceProjectId": str(PROJECT_ID),
+            "sourceDirectory": "source/dir",
+            "name": "template name",
+        },
+    )

--- a/tests/clients/test_template.py
+++ b/tests/clients/test_template.py
@@ -25,7 +25,7 @@ def test_publish_new(mocker):
     mocker.patch.object(TemplateClient, "_post_raw")
 
     client = TemplateClient(mocker.Mock())
-    client.publish_new("template name", "source/dir", PROJECT_ID)
+    client.publish_new(PROJECT_ID, "template name", "source/dir")
 
     TemplateClient._post_raw.assert_called_once_with(
         "template",


### PR DESCRIPTION
(Reopening https://github.com/facultyai/faculty/pull/170 which I accidentally merged 🤦 )

This PR adds 2 clients that we need to implement the faculty template new CLI command (see the CLI changes).

The template client that talks to kanto is quite straightforward.

The notification client is a bit different from clients for other services because it uses server-sent events

I've used an external library for SSEs. We have an existing code snippet for an SSE client in faculty-cli I could copy, but it didn't seem it was worth debugging much. The library works and by looking at the source code it seems more robust than our minimalistic implementation.

This depends on exposing frontend on https://frontend.services.???.my.faculty.ai and also allowing SSEs from frontend.sml-services (for which I have changes ready and validated it works):
<img width="764" alt="Screenshot 2020-09-10 at 11 00 16" src="https://user-images.githubusercontent.com/6483817/92762004-7dd35c80-f392-11ea-81c5-e5d60d19501a.png">
