### PR TITLE
Add template to project from directory

### DIFF
--- a/faculty/clients/notification.py
+++ b/faculty/clients/notification.py
@@ -178,7 +178,7 @@ class AddTemplateToProjectFromDirectoryNotifications:
                 e.event == "@SSE/PROJECT_TEMPLATE_APPLY_FROM_DIRECTORY"
                 "_ADD_TO_PROJECT_FAILED"
             ):
-                body = json.loads(e.data)
+                json.loads(e.data)
                 # TODO backend needs to return rendering errors here
                 msg = "Failed to apply template to directory"
                 raise TemplatePublishingError(msg)

--- a/faculty/clients/notification.py
+++ b/faculty/clients/notification.py
@@ -179,7 +179,8 @@ class AddTemplateToProjectFromDirectoryNotifications:
                 "_ADD_TO_PROJECT_FAILED"
             ):
                 body = json.loads(e.data)
-                msg = _extract_publishing_error_msg(body)
+                # TODO backend needs to return rendering errors here
+                msg = "Failed to apply template to directory"
                 raise TemplatePublishingError(msg)
             elif (
                 e.event == "@SSE/PROJECT_TEMPLATE_APPLY_FROM_DIRECTORY"

--- a/faculty/clients/notification.py
+++ b/faculty/clients/notification.py
@@ -57,7 +57,7 @@ class NotificationClient(BaseClient):
         client = sseclient.SSEClient(response)
         return client.events()
 
-    def get_publish_template_notifications(self, user_id, source_project_id):
+    def publish_template_notifications(self, user_id, source_project_id):
         """Get notification events of a template publishing operation.
 
         Only returns when success or failure events are received for the given
@@ -78,6 +78,34 @@ class NotificationClient(BaseClient):
             return body.get("sourceProjectId") == str(source_project_id)
 
         return PublishTemplateNotifications(
+            filter(is_publishing_event, self.user_updates(user_id))
+        )
+
+    def add_to_project_from_dir_notifications(
+        self, user_id, target_project_id
+    ):
+        """Get notifications of a "add to project from directory" operation.
+
+        Only returns when success or failure events are received for the given
+        target project_id. Events with other project IDs are ignored.
+
+        Parameters
+        ----------
+        user_id : uuid.UUID
+            The user who started the publish operation.
+        target_project_id : uuid.UUID
+            The project from which the template was published.
+        """
+
+        def is_publishing_event(event):
+            if not event.event.startswith(
+                "@SSE/PROJECT_TEMPLATE_APPLY_FROM_DIRECTORY_ADD_TO_PROJECT"
+            ):
+                return False
+            body = json.loads(event.data)
+            return body.get("projectId") == str(target_project_id)
+
+        return AddTemplateToProjectFromDirectoryNotifications(
             filter(is_publishing_event, self.user_updates(user_id))
         )
 
@@ -105,7 +133,7 @@ class TemplatePublishingError(Exception):
 
 class PublishTemplateNotifications:
     """
-    Wrapper around notification events from template publishig.
+    Wrapper around notification events from template publishing.
 
     Parameters
     ----------
@@ -125,4 +153,36 @@ class PublishTemplateNotifications:
                 msg = _extract_publishing_error_msg(body)
                 raise TemplatePublishingError(msg)
             elif e.event == "@SSE/PROJECT_TEMPLATE_PUBLISH_NEW_COMPLETED":
+                return
+
+
+class AddTemplateToProjectFromDirectoryNotifications:
+    """
+    Wrapper around notification events from the "add template to project from
+    directory" operation
+
+    Parameters
+    ----------
+    events : generator
+            Events from the "add to project from directory" operation.
+            Should be already filtered for a project and user IDs.
+    """
+
+    def __init__(self, events):
+        self.events = events
+
+    def wait_for_completion(self):
+        """Block until template publishing completes or fails."""
+        for e in self.events:
+            if (
+                e.event
+                == "@SSE/PROJECT_TEMPLATE_APPLY_FROM_DIRECTORY_ADD_TO_PROJECT_FAILED"
+            ):
+                body = json.loads(e.data)
+                msg = _extract_publishing_error_msg(body)
+                raise TemplatePublishingError(msg)
+            elif (
+                e.event
+                == "@SSE/PROJECT_TEMPLATE_APPLY_FROM_DIRECTORY_ADD_TO_PROJECT_COMPLETED"
+            ):
                 return

--- a/faculty/clients/notification.py
+++ b/faculty/clients/notification.py
@@ -133,13 +133,13 @@ class TemplatePublishingError(Exception):
 
 class PublishTemplateNotifications:
     """
-    Wrapper around notification events from template publishing.
+    Events from the "publish new template" operation.
 
     Parameters
     ----------
     events : generator
-            Publishing events. Should be already filtered for a project and
-            user IDs.
+        Publishing events. Should be already filtered for a project and
+        user IDs.
     """
 
     def __init__(self, events):
@@ -158,14 +158,13 @@ class PublishTemplateNotifications:
 
 class AddTemplateToProjectFromDirectoryNotifications:
     """
-    Wrapper around notification events from the "add template to project from
-    directory" operation
+    Events from the "add template to project from directory" operation.
 
     Parameters
     ----------
     events : generator
-            Events from the "add to project from directory" operation.
-            Should be already filtered for a project and user IDs.
+        Events from the "add to project from directory" operation.
+        Should be already filtered for a project and user IDs.
     """
 
     def __init__(self, events):

--- a/faculty/clients/notification.py
+++ b/faculty/clients/notification.py
@@ -117,7 +117,7 @@ def _extract_publishing_error_msg(error_body):
             return error_body["error"]
         elif code == "template_rendering_error":
             errors = error_body["errors"]
-            msg = "Failed to render the template with default parameters:"
+            msg = "Failed to render the template:"
             for e in errors:
                 msg += "\n\t{} in file {}".format(e["error"], e["path"])
             return msg
@@ -177,9 +177,8 @@ class AddTemplateToProjectFromDirectoryNotifications:
                 e.event == "@SSE/PROJECT_TEMPLATE_APPLY_FROM_DIRECTORY"
                 "_ADD_TO_PROJECT_FAILED"
             ):
-                json.loads(e.data)
-                # TODO backend needs to return rendering errors here
-                msg = "Failed to apply template to directory"
+                body = json.loads(e.data)
+                msg = _extract_publishing_error_msg(body)
                 raise TemplatePublishingError(msg)
             elif (
                 e.event == "@SSE/PROJECT_TEMPLATE_APPLY_FROM_DIRECTORY"

--- a/faculty/clients/notification.py
+++ b/faculty/clients/notification.py
@@ -175,14 +175,14 @@ class AddTemplateToProjectFromDirectoryNotifications:
         """Block until template publishing completes or fails."""
         for e in self.events:
             if (
-                e.event
-                == "@SSE/PROJECT_TEMPLATE_APPLY_FROM_DIRECTORY_ADD_TO_PROJECT_FAILED"
+                e.event == "@SSE/PROJECT_TEMPLATE_APPLY_FROM_DIRECTORY"
+                "_ADD_TO_PROJECT_FAILED"
             ):
                 body = json.loads(e.data)
                 msg = _extract_publishing_error_msg(body)
                 raise TemplatePublishingError(msg)
             elif (
-                e.event
-                == "@SSE/PROJECT_TEMPLATE_APPLY_FROM_DIRECTORY_ADD_TO_PROJECT_COMPLETED"
+                e.event == "@SSE/PROJECT_TEMPLATE_APPLY_FROM_DIRECTORY"
+                "_ADD_TO_PROJECT_COMPLETED"
             ):
                 return

--- a/faculty/clients/template.py
+++ b/faculty/clients/template.py
@@ -63,10 +63,8 @@ class TemplateClient(BaseClient):
             "parameterValues": parameters,
         }
         response = self._post_raw(endpoint, json=payload, check_status=False)
-        print(response.status_code)
-        print(response.text)
         if 200 <= response.status_code < 300:
-            return
+            return response
         elif 400 <= response.status_code < 500:
             response_body = response.json()
             error_code = response_body.get("errorCode")
@@ -86,14 +84,8 @@ class TemplateClient(BaseClient):
                 raise GenericParsingErrorSchema().load(response_body)
             elif error_code == "workspace_files_validation_error":
                 raise WorkspaceFilesValidationErrorSchema().load(response_body)
-            else:
-                _unexpected_response(response)
         else:
-            _unexpected_response(response)
-
-
-def _unexpected_response(response):
-    raise Exception("Unexpected response from the server:\n", response.text)
+            raise Exception("Unexpected response from the server:\n", response.text)
 
 
 class TemplateException(Exception):

--- a/faculty/clients/template.py
+++ b/faculty/clients/template.py
@@ -72,26 +72,20 @@ class TemplateClient(BaseClient):
 
 
 def _handle_publishing_error(exception):
-    if exception.error_code == "resources_validation_failure":
-        raise ResourceValidationErrorResponseSchema().load(
-            exception.response.json()
-        )
-    elif exception.error_code == "parameter_validation_failure":
-        raise ParameterValidationErrorSchema().load(exception.response.json())
-    elif exception.error_code == "template_retrieval_failure":
-        raise TemplateRetrievalErrorResponseSchema().load(
-            exception.response.json()
-        )
-    elif exception.error_code == "default_parameters_parsing_error":
-        raise DefaultParametersParsingErrorSchema().load(
-            exception.response.json()
-        )
-    elif exception.error_code == "generic_parsing_failure":
-        raise GenericParsingErrorSchema().load(exception.response.json())
-    elif exception.error_code == "workspace_files_validation_error":
-        raise WorkspaceFilesValidationErrorSchema().load(
-            exception.response.json()
-        )
+    code = exception.error_code
+    body = exception.response.json()
+    if code == "resources_validation_failure":
+        raise ResourceValidationErrorResponseSchema().load(body)
+    elif code == "parameter_validation_failure":
+        raise ParameterValidationErrorSchema().load(body)
+    elif code == "template_retrieval_failure":
+        raise TemplateRetrievalErrorResponseSchema().load(body)
+    elif code == "default_parameters_parsing_error":
+        raise DefaultParametersParsingErrorSchema().load(body)
+    elif code == "generic_parsing_failure":
+        raise GenericParsingErrorSchema().load(body)
+    elif code == "workspace_files_validation_error":
+        raise WorkspaceFilesValidationErrorSchema().load(body)
     else:
         raise
 

--- a/faculty/clients/template.py
+++ b/faculty/clients/template.py
@@ -285,7 +285,8 @@ class ResourceValidationErrorResponseSchema(BaseSchema):
 
     @post_load
     def make_error(self, data, **kwargs):
-        return ResourceValidationError.from_errors(**data)
+        errors = data["errors"]
+        return ResourceValidationError(**errors)
 
 
 class ResourceValidationError(TemplateException):
@@ -295,16 +296,6 @@ class ResourceValidationError(TemplateException):
         self.environments = environments
         self.jobs = jobs
         self.workspace = workspace
-
-    @staticmethod
-    def from_errors(errors):
-        return ResourceValidationError(
-            apps=errors["apps"],
-            apis=errors["apis"],
-            environments=errors["environments"],
-            jobs=errors["jobs"],
-            workspace=errors["workspace"],
-        )
 
 
 class ParameterValidationError(TemplateException):
@@ -327,15 +318,6 @@ class TemplateRetrievalError(TemplateException):
         self.environments = environments
         self.jobs = jobs
 
-    @staticmethod
-    def from_errors(errors):
-        return TemplateRetrievalError(
-            apps=errors["apps"],
-            apis=errors["apis"],
-            environments=errors["environments"],
-            jobs=errors["jobs"],
-        )
-
 
 class TemplateRetrievalErrorSchema(BaseSchema):
     apps = fields.List(fields.String(), required=True)
@@ -349,4 +331,5 @@ class TemplateRetrievalErrorResponseSchema(BaseSchema):
 
     @post_load()
     def make_error(self, data, **kwargs):
-        return TemplateRetrievalError.from_errors(**data)
+        errors = data["errors"]
+        return TemplateRetrievalError(**errors)

--- a/faculty/clients/template.py
+++ b/faculty/clients/template.py
@@ -15,8 +15,11 @@
 """
 Interact with the Faculty knowledge centre templates.
 """
+from collections import namedtuple
 
-from faculty.clients.base import BadRequest, Conflict, BaseClient
+from marshmallow import fields, post_load
+
+from faculty.clients.base import BaseClient, BaseSchema
 
 
 class TemplateClient(BaseClient):
@@ -57,7 +60,7 @@ class TemplateClient(BaseClient):
             "sourceProjectId": str(source_project_id),
             "sourceDirectory": source_directory,
             "targetDirectory": target_directory,
-            "parameterValues": dict(parameters),
+            "parameterValues": parameters,
         }
         response = self._post_raw(endpoint, json=payload, check_status=False)
         print(response.status_code)
@@ -68,16 +71,23 @@ class TemplateClient(BaseClient):
             response_body = response.json()
             error_code = response_body.get("errorCode")
             if error_code == "resources_validation_failure":
-                _resource_validation_error(response_body)
+                raise ResourceValidationFailureResponseSchema().load(
+                    response_body
+                )
+                # _resource_validation_error(response_body)
             elif error_code == "parameter_validation_failure":
-                msg = "Parameter validation failed:"
-                for e in response_body["errors"]["parameters"]:
-                    msg += "\n" + e
-                raise ParameterValidationFailure(msg)
+                raise ParameterValidationFailureSchema().load(response_body)
+                # msg = "Parameter validation failed:"
+                # for e in response_body["errors"]["parameters"]:
+                #     msg += "\n" + e
+                # raise ParameterValidationFailure(msg)
             elif error_code == "template_retrieval_failure":
-                raise _retrieval_error(response_body)
+                raise TemplateRetrievalFailureResponseSchema().load(
+                    response_body
+                )
+                # raise _retrieval_error(response_body)
             elif error_code == "default_parameters_parsing_error":
-                raise DefaultParametersParsingError(response_body["error"])
+                raise DefaultParametersParsingErrorSchema().load(response_body)
             elif error_code == "generic_parsing_failure":
                 raise TemplateRetrievalFailure(response_body["error"])
             # TODO more cases
@@ -87,58 +97,58 @@ class TemplateClient(BaseClient):
             _unexpected_response(response)
 
 
-def _map_prefix(prefix, errors):
-    return [prefix + e for e in errors]
-
-
-def _one_per_line(error_message_lists):
-    messages = [msg for sublist in error_message_lists for msg in sublist]
-    return "\n".join(messages)
-
-
-def _retrieval_error(response_body):
-    errors = response_body["errors"]
-    apps = errors["apps"]
-    apis = errors["apis"]
-    envs = errors["environments"]
-    jobs = errors["jobs"]
-    message_lists = [
-        _map_prefix(prefix, errors)
-        for prefix, errors in [
-            ("Error reading app resource definition: ", apps),
-            ("Error reading API resource definition: ", apis),
-            ("Error reading environment resource definition: ", envs),
-            ("Error reading app job definition: ", jobs),
-        ]
-    ]
-    raise TemplateRetrievalFailure(_one_per_line(message_lists))
-
-
-def _resource_validation_error(response_body):
-    errors = response_body["errors"]
-    apps = errors["apps"]
-    apis = errors["apis"]
-    envs = errors["environments"]
-    jobs = errors["jobs"]
-    workspace = errors["workspace"]
-    message_lists = [
-        _map_prefix(prefix, errors)
-        for prefix, errors in [
-            ("App subdomain already exists: ", apps["subdomainConflicts"]),
-            ("App name already exists: ", apps["nameConflicts"]),
-            ("Invalid app working directory: ", apps["invalidWorkingDirs"]),
-            ("API subdomain already exists: ", apis["subdomainConflicts"]),
-            ("API name already exists: ", apis["nameConflicts"]),
-            ("Invalid API working directory: ", apis["invalidWorkingDirs"]),
-            ("Environment name already exists: ", envs["nameConflicts"]),
-            ("Invalid environment name: ", envs["invalidNames"]),
-            ("Job name already exists: ", jobs["nameConflicts"]),
-            ("Invalid job name: ", jobs["invalidNames"]),
-            ("Invalid job working directory: ", jobs["invalidWorkingDirs"]),
-            ("Workspace file conflicts: ", workspace["nameConflicts"]),
-        ]
-    ]
-    raise ResourceValidationFailure(_one_per_line(message_lists))
+# def _map_prefix(prefix, errors):
+#     return [prefix + e for e in errors]
+#
+#
+# def _one_per_line(error_message_lists):
+#     messages = [msg for sublist in error_message_lists for msg in sublist]
+#     return "\n".join(messages)
+#
+#
+# def _retrieval_error(response_body):
+#     errors = response_body["errors"]
+#     apps = errors["apps"]
+#     apis = errors["apis"]
+#     envs = errors["environments"]
+#     jobs = errors["jobs"]
+#     message_lists = [
+#         _map_prefix(prefix, errors)
+#         for prefix, errors in [
+#             ("Error reading app resource definition: ", apps),
+#             ("Error reading API resource definition: ", apis),
+#             ("Error reading environment resource definition: ", envs),
+#             ("Error reading app job definition: ", jobs),
+#         ]
+#     ]
+#     raise TemplateRetrievalFailure(_one_per_line(message_lists))
+#
+#
+# def _resource_validation_error(response_body):
+#     errors = response_body["errors"]
+#     apps = errors["apps"]
+#     apis = errors["apis"]
+#     envs = errors["environments"]
+#     jobs = errors["jobs"]
+#     workspace = errors["workspace"]
+#     message_lists = [
+#         _map_prefix(prefix, errors)
+#         for prefix, errors in [
+#             ("App subdomain already exists: ", apps["subdomainConflicts"]),
+#             ("App name already exists: ", apps["nameConflicts"]),
+#             ("Invalid app working directory: ", apps["invalidWorkingDirs"]),
+#             ("API subdomain already exists: ", apis["subdomainConflicts"]),
+#             ("API name already exists: ", apis["nameConflicts"]),
+#             ("Invalid API working directory: ", apis["invalidWorkingDirs"]),
+#             ("Environment name already exists: ", envs["nameConflicts"]),
+#             ("Invalid environment name: ", envs["invalidNames"]),
+#             ("Job name already exists: ", jobs["nameConflicts"]),
+#             ("Invalid job name: ", jobs["invalidNames"]),
+#             ("Invalid job working directory: ", jobs["invalidWorkingDirs"]),
+#             ("Workspace file conflicts: ", workspace["nameConflicts"]),
+#         ]
+#     ]
+#     raise ResourceValidationFailure(_one_per_line(message_lists))
 
 
 def _unexpected_response(response):
@@ -150,16 +160,196 @@ class TemplateException(Exception):
 
 
 class DefaultParametersParsingError(TemplateException):
-    pass
+    def __init__(self, error):
+        self.errors = error
 
 
-class TemplateRetrievalFailure(TemplateException):
-    pass
+class DefaultParametersParsingErrorSchema(BaseSchema):
+    error = fields.String(required=True)
+
+    @post_load
+    def make_error(self, data, **kwargs):
+        return DefaultParametersParsingError(**data)
+
+
+class AppValidationFailureSchema(BaseSchema):
+    subdomain_conflicts = fields.List(
+        fields.String(), data_key="subdomainConflicts", required=True
+    )
+    name_conflicts = fields.List(
+        fields.String(), data_key="nameConflicts", required=True
+    )
+    invalid_working_dirs = fields.List(
+        fields.String(), data_key="invalidWorkingDirs", required=True
+    )
+
+    @post_load
+    def make_failure(self, data, **kwargs):
+        return AppValidationFailure(**data)
+
+
+AppValidationFailure = namedtuple(
+    "AppValidationFailure",
+    ["subdomain_conflicts", "name_conflicts", "invalid_working_dirs"],
+)
+
+
+class ApiValidationFailureSchema(BaseSchema):
+    subdomain_conflicts = fields.List(
+        fields.String(), data_key="subdomainConflicts", required=True
+    )
+    name_conflicts = fields.List(
+        fields.String(), data_key="nameConflicts", required=True
+    )
+    invalid_working_dirs = fields.List(
+        fields.String(), data_key="invalidWorkingDirs", required=True
+    )
+
+    @post_load
+    def make_failure(self, data, **kwargs):
+        return ApiValidationFailure(**data)
+
+
+ApiValidationFailure = namedtuple(
+    "ApiValidationFailure",
+    ["subdomain_conflicts", "name_conflicts", "invalid_working_dirs"],
+)
+
+
+class EnvironmentValidationFailureSchema(BaseSchema):
+    name_conflicts = fields.List(
+        fields.String(), data_key="nameConflicts", required=True
+    )
+    invalid_names = fields.List(
+        fields.String(), data_key="invalidNames", required=True
+    )
+
+    @post_load
+    def make_failure(self, data, **kwargs):
+        return EnvironmentValidationFailure(**data)
+
+
+EnvironmentValidationFailure = namedtuple(
+    "EnvironmentValidationFailure", ["name_conflicts", "invalid_names"]
+)
+
+
+class JobValidationFailureSchema(BaseSchema):
+    name_conflicts = fields.List(
+        fields.String(), data_key="nameConflicts", required=True
+    )
+    invalid_working_dirs = fields.List(
+        fields.String(), data_key="invalidWorkingDirs", required=True
+    )
+    invalid_names = fields.List(
+        fields.String(), data_key="invalidNames", required=True
+    )
+
+    @post_load
+    def make_failure(self, data, **kwargs):
+        return JobValidationFailure(**data)
+
+
+JobValidationFailure = namedtuple(
+    "JobValidationFailure",
+    ["name_conflicts", "invalid_working_dirs", "invalid_names"],
+)
+
+
+class WorkspaceValidationFailureSchema(BaseSchema):
+    name_conflicts = fields.List(
+        fields.String(), data_key="nameConflicts", required=True
+    )
+
+    @post_load
+    def make_failure(self, data, **kwargs):
+        return WorkspaceValidationFailure(**data)
+
+
+WorkspaceValidationFailure = namedtuple(
+    "WorkspaceValidationFailure", ["name_conflicts"]
+)
+
+
+class ResourceValidationFailuresSchema(BaseSchema):
+    apps = fields.Nested(AppValidationFailureSchema(), required=True)
+    apis = fields.Nested(ApiValidationFailureSchema(), required=True)
+    environments = fields.Nested(
+        EnvironmentValidationFailureSchema(), required=True
+    )
+    jobs = fields.Nested(JobValidationFailureSchema(), required=True)
+    workspace = fields.Nested(
+        WorkspaceValidationFailureSchema(), required=True
+    )
+
+
+class ResourceValidationFailureResponseSchema(BaseSchema):
+    errors = fields.Nested(ResourceValidationFailuresSchema(), required=True)
+
+    @post_load
+    def make_failure(self, data, **kwargs):
+        return ResourceValidationFailure.from_errors(**data)
 
 
 class ResourceValidationFailure(TemplateException):
-    pass
+    def __init__(self, apps, apis, environments, jobs, workspace):
+        self.apps = apps
+        self.apis = apis
+        self.environments = environments
+        self.jobs = jobs
+        self.workspace = workspace
+
+    @staticmethod
+    def from_errors(errors):
+        return ResourceValidationFailure(
+            apps=errors["apps"],
+            apis=errors["apis"],
+            environments=errors["environments"],
+            jobs=errors["jobs"],
+            workspace=errors["workspace"],
+        )
 
 
 class ParameterValidationFailure(TemplateException):
-    pass
+    def __init__(self, errors):
+        self.errors = errors
+
+
+class ParameterValidationFailureSchema(BaseSchema):
+    errors = fields.List(fields.String(), required=True)
+
+    @post_load()
+    def make_failure(self, data, **kwargs):
+        return ParameterValidationFailure(**data)
+
+
+class TemplateRetrievalFailure(TemplateException):
+    def __init__(self, apps, apis, environments, jobs):
+        self.apps = apps
+        self.apis = apis
+        self.environments = environments
+        self.jobs = jobs
+
+    @staticmethod
+    def from_errors(errors):
+        return TemplateRetrievalFailure(
+            apps=errors["apps"],
+            apis=errors["apis"],
+            environments=errors["environments"],
+            jobs=errors["jobs"],
+        )
+
+
+class TemplateRetrievalFailureSchema(BaseSchema):
+    apps = fields.List(fields.String(), required=True)
+    apis = fields.List(fields.String(), required=True)
+    environments = fields.List(fields.String(), required=True)
+    jobs = fields.List(fields.String(), required=True)
+
+
+class TemplateRetrievalFailureResponseSchema(BaseSchema):
+    errors = fields.Nested(TemplateRetrievalFailureSchema(), required=True)
+
+    @post_load()
+    def make_failure(self, data, **kwargs):
+        return TemplateRetrievalFailure.from_errors(**data)

--- a/faculty/clients/template.py
+++ b/faculty/clients/template.py
@@ -16,7 +16,7 @@
 Interact with the Faculty knowledge centre templates.
 """
 
-from faculty.clients.base import BaseClient
+from faculty.clients.base import BadRequest, Conflict, BaseClient
 
 
 class TemplateClient(BaseClient):
@@ -43,3 +43,123 @@ class TemplateClient(BaseClient):
             "name": template,
         }
         return self._post_raw(endpoint, json=payload)
+
+    def add_to_project_from_directory(
+        self,
+        source_project_id,
+        source_directory,
+        target_project_id,
+        target_directory,
+        parameters,
+    ):
+        endpoint = "project/{}/apply".format(target_project_id)
+        payload = {
+            "sourceProjectId": str(source_project_id),
+            "sourceDirectory": source_directory,
+            "targetDirectory": target_directory,
+            "parameterValues": dict(parameters),
+        }
+        response = self._post_raw(endpoint, json=payload, check_status=False)
+        print(response.status_code)
+        print(response.text)
+        if 200 <= response.status_code < 300:
+            return
+        elif 400 <= response.status_code < 500:
+            response_body = response.json()
+            error_code = response_body.get("errorCode")
+            if error_code == "resources_validation_failure":
+                _resource_validation_error(response_body)
+            elif error_code == "parameter_validation_failure":
+                msg = "Parameter validation failed:"
+                for e in response_body["errors"]["parameters"]:
+                    msg += "\n" + e
+                raise ParameterValidationFailure(msg)
+            elif error_code == "template_retrieval_failure":
+                raise _retrieval_error(response_body)
+            elif error_code == "default_parameters_parsing_error":
+                raise DefaultParametersParsingError(response_body["error"])
+            elif error_code == "generic_parsing_failure":
+                raise TemplateRetrievalFailure(response_body["error"])
+            # TODO more cases
+            else:
+                _unexpected_response(response)
+        else:
+            _unexpected_response(response)
+
+
+def _map_prefix(prefix, errors):
+    return [prefix + e for e in errors]
+
+
+def _one_per_line(error_message_lists):
+    messages = [msg for sublist in error_message_lists for msg in sublist]
+    return "\n".join(messages)
+
+
+def _retrieval_error(response_body):
+    errors = response_body["errors"]
+    apps = errors["apps"]
+    apis = errors["apis"]
+    envs = errors["environments"]
+    jobs = errors["jobs"]
+    message_lists = [
+        _map_prefix(prefix, errors)
+        for prefix, errors in [
+            ("Error reading app resource definition: ", apps),
+            ("Error reading API resource definition: ", apis),
+            ("Error reading environment resource definition: ", envs),
+            ("Error reading app job definition: ", jobs),
+        ]
+    ]
+    raise TemplateRetrievalFailure(_one_per_line(message_lists))
+
+
+def _resource_validation_error(response_body):
+    errors = response_body["errors"]
+    apps = errors["apps"]
+    apis = errors["apis"]
+    envs = errors["environments"]
+    jobs = errors["jobs"]
+    workspace = errors["workspace"]
+    message_lists = [
+        _map_prefix(prefix, errors)
+        for prefix, errors in [
+            ("App subdomain already exists: ", apps["subdomainConflicts"]),
+            ("App name already exists: ", apps["nameConflicts"]),
+            ("Invalid app working directory: ", apps["invalidWorkingDirs"]),
+            ("API subdomain already exists: ", apis["subdomainConflicts"]),
+            ("API name already exists: ", apis["nameConflicts"]),
+            ("Invalid API working directory: ", apis["invalidWorkingDirs"]),
+            ("Environment name already exists: ", envs["nameConflicts"]),
+            ("Invalid environment name: ", envs["invalidNames"]),
+            ("Job name already exists: ", jobs["nameConflicts"]),
+            ("Invalid job name: ", jobs["invalidNames"]),
+            ("Invalid job working directory: ", jobs["invalidWorkingDirs"]),
+            ("Workspace file conflicts: ", workspace["nameConflicts"]),
+        ]
+    ]
+    raise ResourceValidationFailure(_one_per_line(message_lists))
+
+
+def _unexpected_response(response):
+    raise Exception("Unexpected response from the server:\n", response.text)
+
+
+class TemplateException(Exception):
+    pass
+
+
+class DefaultParametersParsingError(TemplateException):
+    pass
+
+
+class TemplateRetrievalFailure(TemplateException):
+    pass
+
+
+class ResourceValidationFailure(TemplateException):
+    pass
+
+
+class ParameterValidationFailure(TemplateException):
+    pass

--- a/tests/clients/test_notification.py
+++ b/tests/clients/test_notification.py
@@ -243,8 +243,7 @@ def test_add_to_project_from_dir_notifications_filter(mocker):
             data=json.dumps({"projectId": str(PROJECT_ID)}),
         )
         yield Event(
-            event="@SSE/OTHER",
-            data=json.dumps({"projectId": str(PROJECT_ID)}),
+            event="@SSE/OTHER", data=json.dumps({"projectId": str(PROJECT_ID)})
         )
 
     user_updates_mock = mocker.patch.object(

--- a/tests/clients/test_notification.py
+++ b/tests/clients/test_notification.py
@@ -63,14 +63,14 @@ def test_wait_for_completion_success(mocker):
     )
     client = NotificationClient(mocker.Mock())
 
-    publish_notifications = client.get_publish_template_notifications(
+    publish_notifications = client.publish_template_notifications(
         USER_ID, PROJECT_ID
     )
     publish_notifications.wait_for_completion()
     user_updates_mock.assert_called_once_with(USER_ID)
 
 
-def test_get_publish_template_notifications_filter(mocker):
+def test_publish_template_notifications_filter(mocker):
     def events():
         yield Event(
             event="@SSE/PROJECT_TEMPLATE_PUBLISH_NEW_FAILED",
@@ -98,7 +98,7 @@ def test_get_publish_template_notifications_filter(mocker):
     )
     client = NotificationClient(mocker.Mock())
 
-    publish_notifications = client.get_publish_template_notifications(
+    publish_notifications = client.publish_template_notifications(
         USER_ID, PROJECT_ID
     )
     event_data = [(e.event, e.data) for e in publish_notifications.events]
@@ -134,7 +134,7 @@ def test_wait_for_completion_errors(mocker, error_code):
         NotificationClient, "user_updates", return_value=events()
     )
     client = NotificationClient(mocker.Mock())
-    publish_notifications = client.get_publish_template_notifications(
+    publish_notifications = client.publish_template_notifications(
         USER_ID, PROJECT_ID
     )
     with pytest.raises(TemplatePublishingError, match="dummy error message"):
@@ -162,7 +162,7 @@ def test_wait_for_completion_rendering_errors(mocker):
         NotificationClient, "user_updates", return_value=events()
     )
     client = NotificationClient(mocker.Mock())
-    publish_notifications = client.get_publish_template_notifications(
+    publish_notifications = client.publish_template_notifications(
         USER_ID, PROJECT_ID
     )
     expected_message = """Failed to render the template with default parameters:
@@ -189,7 +189,7 @@ def test_wait_for_completion_rendering_unexpected_error_code(mocker):
         NotificationClient, "user_updates", return_value=events()
     )
     client = NotificationClient(mocker.Mock())
-    publish_notifications = client.get_publish_template_notifications(
+    publish_notifications = client.publish_template_notifications(
         USER_ID, PROJECT_ID
     )
     with pytest.raises(
@@ -210,7 +210,7 @@ def test_wait_for_completion_rendering_no_error_code(mocker):
         NotificationClient, "user_updates", return_value=events()
     )
     client = NotificationClient(mocker.Mock())
-    publish_notifications = client.get_publish_template_notifications(
+    publish_notifications = client.publish_template_notifications(
         USER_ID, PROJECT_ID
     )
     with pytest.raises(

--- a/tests/clients/test_template.py
+++ b/tests/clients/test_template.py
@@ -15,23 +15,201 @@
 
 import uuid
 
-from faculty.clients.template import TemplateClient
+import pytest
 
+from faculty.clients.template import (
+    TemplateClient,
+    ResourceValidationFailure,
+    AppValidationFailure,
+    ApiValidationFailure,
+    EnvironmentValidationFailure,
+    JobValidationFailure,
+    WorkspaceValidationFailure,
+    ParameterValidationFailure,
+    TemplateRetrievalFailure,
+    DefaultParametersParsingError,
+)
 
-PROJECT_ID = uuid.uuid4()
+SOURCE_PROJECT_ID = uuid.uuid4()
+TARGET_PROJECT_ID = uuid.uuid4()
 
 
 def test_publish_new(mocker):
     mocker.patch.object(TemplateClient, "_post_raw")
 
     client = TemplateClient(mocker.Mock())
-    client.publish_new(PROJECT_ID, "template name", "source/dir")
+    client.publish_new(SOURCE_PROJECT_ID, "template name", "source/dir")
 
     TemplateClient._post_raw.assert_called_once_with(
         "template",
         json={
-            "sourceProjectId": str(PROJECT_ID),
+            "sourceProjectId": str(SOURCE_PROJECT_ID),
             "sourceDirectory": "source/dir",
             "name": "template name",
         },
     )
+
+
+def test_add_to_project_from_directory(mocker):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 202
+    mocker.patch.object(
+        TemplateClient, "_post_raw", return_value=mock_response
+    )
+
+    client = TemplateClient(mocker.Mock())
+    client.add_to_project_from_directory(
+        SOURCE_PROJECT_ID,
+        "source/dir",
+        TARGET_PROJECT_ID,
+        "target/dir",
+        {"paramA": "a", "paramB": "B"},
+    )
+
+    TemplateClient._post_raw.assert_called_once_with(
+        "project/{}/apply".format(TARGET_PROJECT_ID),
+        json={
+            "sourceProjectId": str(SOURCE_PROJECT_ID),
+            "sourceDirectory": "source/dir",
+            "targetDirectory": "target/dir",
+            "parameterValues": {"paramA": "a", "paramB": "B"},
+        },
+        check_status=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_response_payload, expected_exception",
+    [
+        (
+            {
+                "errorCode": "resources_validation_failure",
+                "errors": {
+                    "apps": {
+                        "subdomainConflicts": ["app-subdomain-1"],
+                        "nameConflicts": [
+                            "test-app-name-1",
+                            "test-app-name-2",
+                        ],
+                        "invalidWorkingDirs": ["invalid/app/dir"],
+                    },
+                    "apis": {
+                        "subdomainConflicts": ["api-subdomain-1"],
+                        "nameConflicts": ["test-api-name"],
+                        "invalidWorkingDirs": ["invalid/API/dir"],
+                    },
+                    "environments": {
+                        "nameConflicts": ["test-env-name"],
+                        "invalidNames": ["invalid#env"],
+                    },
+                    "jobs": {
+                        "nameConflicts": ["test-job-name"],
+                        "invalidWorkingDirs": [],
+                        "invalidNames": ["invalid#job"],
+                    },
+                    "workspace": {"nameConflicts": ["test-file-path"]},
+                },
+            },
+            ResourceValidationFailure(
+                apps=AppValidationFailure(
+                    subdomain_conflicts=["app-subdomain-1"],
+                    name_conflicts=["test-app-name-1", "test-app-name-2"],
+                    invalid_working_dirs=["invalid/app/dir"],
+                ),
+                apis=ApiValidationFailure(
+                    subdomain_conflicts=["api-subdomain-1"],
+                    name_conflicts=["test-api-name"],
+                    invalid_working_dirs=["invalid/API/dir"],
+                ),
+                environments=EnvironmentValidationFailure(
+                    name_conflicts=["test-env-name"],
+                    invalid_names=["invalid#env"],
+                ),
+                jobs=JobValidationFailure(
+                    name_conflicts=["test-job-name"],
+                    invalid_working_dirs=[],
+                    invalid_names=["invalid#job"],
+                ),
+                workspace=WorkspaceValidationFailure(
+                    name_conflicts=["test-file-path"]
+                ),
+            ),
+        ),
+        (
+            {
+                "errorCode": "parameter_validation_failure",
+                "errors": ["test param 1 error", "test param 2 error"],
+            },
+            ParameterValidationFailure(
+                errors=["test param 1 error", "test param 2 error"]
+            ),
+        ),
+        (
+            {
+                "errorCode": "template_retrieval_failure",
+                "errors": {
+                    "apps": [],
+                    "apis": [],
+                    "environments": [],
+                    "jobs": [],
+                },
+            },
+            TemplateRetrievalFailure(
+                apps=[], apis=[], environments=[], jobs=[]
+            ),
+        ),
+        (
+            {
+                "errorCode": "default_parameters_parsing_error",
+                "error": "parameter error",
+            },
+            DefaultParametersParsingError(error=["parameter error"]),
+        ),
+    ],
+)
+def test_add_to_project_from_directory_errors(
+    mocker, mock_response_payload, expected_exception
+):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 400
+    mocker.patch.object(
+        mock_response, "json", return_value=mock_response_payload
+    )
+    mocker.patch.object(
+        TemplateClient, "_post_raw", return_value=mock_response
+    )
+
+    client = TemplateClient(mocker.Mock())
+    with pytest.raises(type(expected_exception)) as e:
+        client.add_to_project_from_directory(
+            SOURCE_PROJECT_ID,
+            "source/dir",
+            TARGET_PROJECT_ID,
+            "target/dir",
+            {"paramA": "a", "paramB": "B"},
+        )
+
+    assert e.value.args == expected_exception.args
+
+    TemplateClient._post_raw.assert_called_once_with(
+        "project/{}/apply".format(TARGET_PROJECT_ID),
+        json={
+            "sourceProjectId": str(SOURCE_PROJECT_ID),
+            "sourceDirectory": "source/dir",
+            "targetDirectory": "target/dir",
+            "parameterValues": {"paramA": "a", "paramB": "B"},
+        },
+        check_status=False,
+    )
+
+
+#             """App subdomain already exists: app-subdomain-1
+# App name already exists: test-app-name-1
+# App name already exists: test-app-name-2
+# Invalid app working directory: invalid/app/dir
+# API subdomain already exists: api-subdomain-1
+# API name already exists: test-api-name
+# Invalid API working directory: invalid/API/dir
+# Environment name already exists: test-env-name
+# Invalid environment name: invalid#env
+# """,

--- a/tests/clients/test_template.py
+++ b/tests/clients/test_template.py
@@ -19,19 +19,19 @@ import pytest
 
 from faculty.clients.template import (
     TemplateClient,
-    ResourceValidationFailure,
+    ResourceValidationError,
     AppValidationFailure,
     ApiValidationFailure,
     EnvironmentValidationFailure,
     JobValidationFailure,
     WorkspaceValidationFailure,
-    ParameterValidationFailure,
-    TemplateRetrievalFailure,
+    ParameterValidationError,
+    TemplateRetrievalError,
     DefaultParametersParsingError,
     GenericParsingError,
     WorkpaceFilesValidationError,
-    FileTooLargeError,
-    TooManyFilesError,
+    FileTooLarge,
+    TooManyFiles,
 )
 
 SOURCE_PROJECT_ID = uuid.uuid4()
@@ -65,7 +65,7 @@ PUBLISHING_ERRORS = [
                 "workspace": {"nameConflicts": ["test-file-path"]},
             },
         },
-        ResourceValidationFailure(
+        ResourceValidationError(
             apps=AppValidationFailure(
                 subdomain_conflicts=["app-subdomain-1"],
                 name_conflicts=["test-app-name-1", "test-app-name-2"],
@@ -94,7 +94,7 @@ PUBLISHING_ERRORS = [
             "errorCode": "parameter_validation_failure",
             "errors": ["test param 1 error", "test param 2 error"],
         },
-        ParameterValidationFailure(
+        ParameterValidationError(
             errors=["test param 1 error", "test param 2 error"]
         ),
     ),
@@ -108,7 +108,7 @@ PUBLISHING_ERRORS = [
                 "jobs": ["job error"],
             },
         },
-        TemplateRetrievalFailure(
+        TemplateRetrievalError(
             apps=["app error"],
             apis=["API error"],
             environments=["env error"],
@@ -139,11 +139,9 @@ PUBLISHING_ERRORS = [
         },
         WorkpaceFilesValidationError(
             files_too_large=[
-                FileTooLargeError(
-                    "/too/large", actual_size_bytes=2, max_bytes=1
-                )
+                FileTooLarge("/too/large", actual_size_bytes=2, max_bytes=1)
             ],
-            too_many_files=TooManyFilesError(actual_files=2, max_files=1),
+            too_many_files=TooManyFiles(actual_files=2, max_files=1),
         ),
     ),
 ]

--- a/tests/clients/test_template.py
+++ b/tests/clients/test_template.py
@@ -38,8 +38,123 @@ SOURCE_PROJECT_ID = uuid.uuid4()
 TARGET_PROJECT_ID = uuid.uuid4()
 
 
+PUBLISHING_ERRORS = [
+    (
+        {
+            "errorCode": "resources_validation_failure",
+            "errors": {
+                "apps": {
+                    "subdomainConflicts": ["app-subdomain-1"],
+                    "nameConflicts": ["test-app-name-1", "test-app-name-2"],
+                    "invalidWorkingDirs": ["invalid/app/dir"],
+                },
+                "apis": {
+                    "subdomainConflicts": ["api-subdomain-1"],
+                    "nameConflicts": ["test-api-name"],
+                    "invalidWorkingDirs": ["invalid/API/dir"],
+                },
+                "environments": {
+                    "nameConflicts": ["test-env-name"],
+                    "invalidNames": ["invalid#env"],
+                },
+                "jobs": {
+                    "nameConflicts": ["test-job-name"],
+                    "invalidWorkingDirs": [],
+                    "invalidNames": ["invalid#job"],
+                },
+                "workspace": {"nameConflicts": ["test-file-path"]},
+            },
+        },
+        ResourceValidationFailure(
+            apps=AppValidationFailure(
+                subdomain_conflicts=["app-subdomain-1"],
+                name_conflicts=["test-app-name-1", "test-app-name-2"],
+                invalid_working_dirs=["invalid/app/dir"],
+            ),
+            apis=ApiValidationFailure(
+                subdomain_conflicts=["api-subdomain-1"],
+                name_conflicts=["test-api-name"],
+                invalid_working_dirs=["invalid/API/dir"],
+            ),
+            environments=EnvironmentValidationFailure(
+                name_conflicts=["test-env-name"], invalid_names=["invalid#env"]
+            ),
+            jobs=JobValidationFailure(
+                name_conflicts=["test-job-name"],
+                invalid_working_dirs=[],
+                invalid_names=["invalid#job"],
+            ),
+            workspace=WorkspaceValidationFailure(
+                name_conflicts=["test-file-path"]
+            ),
+        ),
+    ),
+    (
+        {
+            "errorCode": "parameter_validation_failure",
+            "errors": ["test param 1 error", "test param 2 error"],
+        },
+        ParameterValidationFailure(
+            errors=["test param 1 error", "test param 2 error"]
+        ),
+    ),
+    (
+        {
+            "errorCode": "template_retrieval_failure",
+            "errors": {
+                "apps": ["app error"],
+                "apis": ["API error"],
+                "environments": ["env error"],
+                "jobs": ["job error"],
+            },
+        },
+        TemplateRetrievalFailure(
+            apps=["app error"],
+            apis=["API error"],
+            environments=["env error"],
+            jobs=["job error"],
+        ),
+    ),
+    (
+        {
+            "errorCode": "default_parameters_parsing_error",
+            "error": "parameter error",
+        },
+        DefaultParametersParsingError(error=["parameter error"]),
+    ),
+    (
+        {
+            "errorCode": "generic_parsing_failure",
+            "error": "generic parsing error",
+        },
+        GenericParsingError(error=["generic parsing error"]),
+    ),
+    (
+        {
+            "errorCode": "workspace_files_validation_error",
+            "filesTooLarge": [
+                {"path": "/too/large", "actualSizeBytes": 2, "maxBytes": 1}
+            ],
+            "tooManyFiles": {"actualFiles": 2, "maxFiles": 1},
+        },
+        WorkpaceFilesValidationError(
+            files_too_large=[
+                FileTooLargeError(
+                    "/too/large", actual_size_bytes=2, max_bytes=1
+                )
+            ],
+            too_many_files=TooManyFilesError(actual_files=2, max_files=1),
+        ),
+    ),
+]
+
+
 def test_publish_new(mocker):
-    mocker.patch.object(TemplateClient, "_post_raw")
+    mock_response = mocker.Mock()
+    mock_response.status_code = 202
+    mocker.patch.object(
+        TemplateClient, "_post_raw", return_value=mock_response
+    )
 
     client = TemplateClient(mocker.Mock())
     client.publish_new(SOURCE_PROJECT_ID, "template name", "source/dir")
@@ -51,6 +166,38 @@ def test_publish_new(mocker):
             "sourceDirectory": "source/dir",
             "name": "template name",
         },
+        check_status=False
+        
+    )
+
+
+@pytest.mark.parametrize(
+    "mock_response_payload, expected_exception", PUBLISHING_ERRORS
+)
+def test_publish_new_errors(mocker, mock_response_payload, expected_exception):
+    mock_response = mocker.Mock()
+    mock_response.status_code = 400
+    mocker.patch.object(
+        mock_response, "json", return_value=mock_response_payload
+    )
+    mocker.patch.object(
+        TemplateClient, "_post_raw", return_value=mock_response
+    )
+
+    client = TemplateClient(mocker.Mock())
+
+    with pytest.raises(type(expected_exception)) as e:
+        client.publish_new(SOURCE_PROJECT_ID, "template name", "source/dir")
+    assert e.value.args == expected_exception.args
+
+    TemplateClient._post_raw.assert_called_once_with(
+        "template",
+        json={
+            "sourceProjectId": str(SOURCE_PROJECT_ID),
+            "sourceDirectory": "source/dir",
+            "name": "template name",
+        },
+        check_status=False
     )
 
 
@@ -83,126 +230,13 @@ def test_add_to_project_from_directory(mocker):
 
 
 @pytest.mark.parametrize(
-    "mock_response_payload, expected_exception",
-    [
-        (
-            {
-                "errorCode": "resources_validation_failure",
-                "errors": {
-                    "apps": {
-                        "subdomainConflicts": ["app-subdomain-1"],
-                        "nameConflicts": [
-                            "test-app-name-1",
-                            "test-app-name-2",
-                        ],
-                        "invalidWorkingDirs": ["invalid/app/dir"],
-                    },
-                    "apis": {
-                        "subdomainConflicts": ["api-subdomain-1"],
-                        "nameConflicts": ["test-api-name"],
-                        "invalidWorkingDirs": ["invalid/API/dir"],
-                    },
-                    "environments": {
-                        "nameConflicts": ["test-env-name"],
-                        "invalidNames": ["invalid#env"],
-                    },
-                    "jobs": {
-                        "nameConflicts": ["test-job-name"],
-                        "invalidWorkingDirs": [],
-                        "invalidNames": ["invalid#job"],
-                    },
-                    "workspace": {"nameConflicts": ["test-file-path"]},
-                },
-            },
-            ResourceValidationFailure(
-                apps=AppValidationFailure(
-                    subdomain_conflicts=["app-subdomain-1"],
-                    name_conflicts=["test-app-name-1", "test-app-name-2"],
-                    invalid_working_dirs=["invalid/app/dir"],
-                ),
-                apis=ApiValidationFailure(
-                    subdomain_conflicts=["api-subdomain-1"],
-                    name_conflicts=["test-api-name"],
-                    invalid_working_dirs=["invalid/API/dir"],
-                ),
-                environments=EnvironmentValidationFailure(
-                    name_conflicts=["test-env-name"],
-                    invalid_names=["invalid#env"],
-                ),
-                jobs=JobValidationFailure(
-                    name_conflicts=["test-job-name"],
-                    invalid_working_dirs=[],
-                    invalid_names=["invalid#job"],
-                ),
-                workspace=WorkspaceValidationFailure(
-                    name_conflicts=["test-file-path"]
-                ),
-            ),
-        ),
-        (
-            {
-                "errorCode": "parameter_validation_failure",
-                "errors": ["test param 1 error", "test param 2 error"],
-            },
-            ParameterValidationFailure(
-                errors=["test param 1 error", "test param 2 error"]
-            ),
-        ),
-        (
-            {
-                "errorCode": "template_retrieval_failure",
-                "errors": {
-                    "apps": ["app error"],
-                    "apis": ["API error"],
-                    "environments": ["env error"],
-                    "jobs": ["job error"],
-                },
-            },
-            TemplateRetrievalFailure(
-                apps=["app error"],
-                apis=["API error"],
-                environments=["env error"],
-                jobs=["job error"],
-            ),
-        ),
-        (
-            {
-                "errorCode": "default_parameters_parsing_error",
-                "error": "parameter error",
-            },
-            DefaultParametersParsingError(error=["parameter error"]),
-        ),
-        (
-            {
-                "errorCode": "generic_parsing_failure",
-                "error": "generic parsing error",
-            },
-            GenericParsingError(error=["generic parsing error"]),
-        ),
-        (
-            {
-                "errorCode": "workspace_files_validation_error",
-                "filesTooLarge": [
-                    {"path": "/too/large", "actualSizeBytes": 2, "maxBytes": 1}
-                ],
-                "tooManyFiles": {"actualFiles": 2, "maxFiles": 1},
-            },
-            WorkpaceFilesValidationError(
-                files_too_large=[
-                    FileTooLargeError(
-                        "/too/large", actual_size_bytes=2, max_bytes=1
-                    )
-                ],
-                too_many_files=TooManyFilesError(actual_files=2, max_files=1),
-            ),
-        ),
-    ],
+    "mock_response_payload, expected_exception", PUBLISHING_ERRORS
 )
 def test_add_to_project_from_directory_errors(
     mocker, mock_response_payload, expected_exception
 ):
     mock_response = mocker.Mock()
-    mock_response.status_code = 400
+    mock_response.status_code = 409
     mocker.patch.object(
         mock_response, "json", return_value=mock_response_payload
     )
@@ -219,7 +253,6 @@ def test_add_to_project_from_directory_errors(
             "target/dir",
             {"paramA": "a", "paramB": "B"},
         )
-
     assert e.value.args == expected_exception.args
 
     TemplateClient._post_raw.assert_called_once_with(

--- a/tests/clients/test_template.py
+++ b/tests/clients/test_template.py
@@ -29,6 +29,9 @@ from faculty.clients.template import (
     TemplateRetrievalFailure,
     DefaultParametersParsingError,
     GenericParsingError,
+    WorkpaceFilesValidationError,
+    FileTooLargeError,
+    TooManyFilesError,
 )
 
 SOURCE_PROJECT_ID = uuid.uuid4()
@@ -175,6 +178,23 @@ def test_add_to_project_from_directory(mocker):
                 "error": "generic parsing error",
             },
             GenericParsingError(error=["generic parsing error"]),
+        ),
+        (
+            {
+                "errorCode": "workspace_files_validation_error",
+                "filesTooLarge": [
+                    {"path": "/too/large", "actualSizeBytes": 2, "maxBytes": 1}
+                ],
+                "tooManyFiles": {"actualFiles": 2, "maxFiles": 1},
+            },
+            WorkpaceFilesValidationError(
+                files_too_large=[
+                    FileTooLargeError(
+                        "/too/large", actual_size_bytes=2, max_bytes=1
+                    )
+                ],
+                too_many_files=TooManyFilesError(actual_files=2, max_files=1),
+            ),
         ),
     ],
 )

--- a/tests/clients/test_template.py
+++ b/tests/clients/test_template.py
@@ -28,6 +28,7 @@ from faculty.clients.template import (
     ParameterValidationFailure,
     TemplateRetrievalFailure,
     DefaultParametersParsingError,
+    GenericParsingError,
 )
 
 SOURCE_PROJECT_ID = uuid.uuid4()
@@ -148,14 +149,17 @@ def test_add_to_project_from_directory(mocker):
             {
                 "errorCode": "template_retrieval_failure",
                 "errors": {
-                    "apps": [],
-                    "apis": [],
-                    "environments": [],
-                    "jobs": [],
+                    "apps": ["app error"],
+                    "apis": ["API error"],
+                    "environments": ["env error"],
+                    "jobs": ["job error"],
                 },
             },
             TemplateRetrievalFailure(
-                apps=[], apis=[], environments=[], jobs=[]
+                apps=["app error"],
+                apis=["API error"],
+                environments=["env error"],
+                jobs=["job error"],
             ),
         ),
         (
@@ -164,6 +168,13 @@ def test_add_to_project_from_directory(mocker):
                 "error": "parameter error",
             },
             DefaultParametersParsingError(error=["parameter error"]),
+        ),
+        (
+            {
+                "errorCode": "generic_parsing_failure",
+                "error": "generic parsing error",
+            },
+            GenericParsingError(error=["generic parsing error"]),
         ),
     ],
 )
@@ -201,15 +212,3 @@ def test_add_to_project_from_directory_errors(
         },
         check_status=False,
     )
-
-
-#             """App subdomain already exists: app-subdomain-1
-# App name already exists: test-app-name-1
-# App name already exists: test-app-name-2
-# Invalid app working directory: invalid/app/dir
-# API subdomain already exists: api-subdomain-1
-# API name already exists: test-api-name
-# Invalid API working directory: invalid/API/dir
-# Environment name already exists: test-env-name
-# Invalid environment name: invalid#env
-# """,

--- a/tests/clients/test_template.py
+++ b/tests/clients/test_template.py
@@ -166,8 +166,7 @@ def test_publish_new(mocker):
             "sourceDirectory": "source/dir",
             "name": "template name",
         },
-        check_status=False
-        
+        check_status=False,
     )
 
 
@@ -197,7 +196,7 @@ def test_publish_new_errors(mocker, mock_response_payload, expected_exception):
             "sourceDirectory": "source/dir",
             "name": "template name",
         },
-        check_status=False
+        check_status=False,
     )
 
 


### PR DESCRIPTION
This adds clients that are needed for the `faculty template add-to-project-from-directory` CLI command (see the [PR](https://github.com/facultyai/faculty-cli/pull/44).

It also unifies some of the error handling logic because the backend responses are almost identical as in the `template publish new` flow (except for some HTTP 409 vs 400 differences, only relevant for frontend).

There is missing error handling logic for the error notifications -- needs to be added to backend yet.