### PR TITLE
Add a client to invite users

### DIFF
--- a/faculty/clients/__init__.py
+++ b/faculty/clients/__init__.py
@@ -17,6 +17,7 @@ from faculty.clients.account import AccountClient
 from faculty.clients.cluster import ClusterClient
 from faculty.clients.environment import EnvironmentClient
 from faculty.clients.experiment import ExperimentClient
+from faculty.clients.invitation import InvitationClient
 from faculty.clients.job import JobClient
 from faculty.clients.log import LogClient
 from faculty.clients.model import ModelClient
@@ -34,6 +35,7 @@ CLIENT_FOR_RESOURCE = {
     "cluster": ClusterClient,
     "environment": EnvironmentClient,
     "experiment": ExperimentClient,
+    "invitation": InvitationClient,
     "job": JobClient,
     "log": LogClient,
     "model": ModelClient,

--- a/faculty/clients/invitation.py
+++ b/faculty/clients/invitation.py
@@ -1,0 +1,56 @@
+# Copyright 2018-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Manage invitations to Faculty and new user creation.
+"""
+
+from faculty.clients.base import BaseClient
+from faculty.clients.user import GlobalRole
+
+
+class InvitationClient(BaseClient):
+    """Client for the Faculty user creation and invitation service.
+
+    Either build this client with a session directly, or use the
+    :func:`faculty.client` helper function:
+
+    >>> client = faculty.client("invitation")
+
+    Parameters
+    ----------
+    session : faculty.session.Session
+        The session to use to make requests
+    """
+
+    _SERVICE_NAME = "ivory"
+
+    def invite_user(self, email, global_roles=None):
+        """Invite a new user to Faculty by email
+
+        Parameters
+        ----------
+        email: str
+            Email address to send the invitation to.
+        global_roles: List[faculty.clients.user.GlobalRole]
+            Global roles to assign to the new user after accepting the invite.
+            Defaults to a basic user.
+        """
+        if global_roles is None:
+            global_roles = [GlobalRole.BASIC_USER]
+        payload = {
+            "email": email,
+            "globalRoles": [r.value for r in global_roles],
+        }
+        self._post_raw("/admin/invitation", json=payload)

--- a/tests/clients/test_invitation.py
+++ b/tests/clients/test_invitation.py
@@ -1,0 +1,54 @@
+# Copyright 2018-2020 Faculty Science Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from faculty.clients.invitation import InvitationClient
+from faculty.clients.user import GlobalRole
+
+
+def test_invite_user(mocker):
+    mocker.patch.object(InvitationClient, "_post_raw")
+
+    client = InvitationClient(mocker.Mock())
+    client.invite_user(
+        "test@email.xyz",
+        global_roles=[
+            GlobalRole.BASIC_USER,
+            GlobalRole.FULL_USER,
+            GlobalRole.ADMIN,
+        ],
+    )
+
+    InvitationClient._post_raw.assert_called_once_with(
+        "/admin/invitation",
+        json={
+            "email": "test@email.xyz",
+            "globalRoles": [
+                "global-basic-user",
+                "global-full-user",
+                "global-admin",
+            ],
+        },
+    )
+
+
+def test_invite_user_default_global_roles(mocker):
+    mocker.patch.object(InvitationClient, "_post_raw")
+
+    client = InvitationClient(mocker.Mock())
+    client.invite_user("test@email.xyz")
+
+    InvitationClient._post_raw.assert_called_once_with(
+        "/admin/invitation",
+        json={"email": "test@email.xyz", "globalRoles": ["global-basic-user"]},
+    )


### PR DESCRIPTION
This will be used from the admin CLI to create a first platform user
as a replacement for the invitation code flow that will be removed.