### PR TITLE
Minor fix to environment schema

### DIFF
--- a/faculty/clients/environment.py
+++ b/faculty/clients/environment.py
@@ -296,7 +296,7 @@ class _PipSchema(BaseSchema):
 
 
 class _CondaSchema(BaseSchema):
-    channels = fields.List(fields.String(), required=True)
+    channels = fields.List(fields.String(), missing=list)
     packages = fields.List(
         fields.Nested(_PythonPackageSchema()), required=True
     )

--- a/faculty/clients/environment.py
+++ b/faculty/clients/environment.py
@@ -282,7 +282,9 @@ class _PythonPackageSchema(BaseSchema):
 
 class _PipSchema(BaseSchema):
     extra_index_urls = fields.List(
-        fields.String(), data_key="extraIndexUrls", required=True
+        fields.String(),
+        data_key="extraIndexUrls",
+        missing=list,
     )
     packages = fields.List(
         fields.Nested(_PythonPackageSchema()), required=True

--- a/tests/clients/test_environment.py
+++ b/tests/clients/test_environment.py
@@ -85,6 +85,11 @@ PIP_BODY = {
 }
 PIP = Pip(extra_index_urls=["http://example.com/"], packages=[PYTHON_PACKAGE])
 
+PIP_BODY_WITHOUT_EXTRA_INDEX_URLS = {"packages": [PYTHON_PACKAGE_BODY]}
+PIP_WITHOUT_EXTRA_INDEX_URLS = Pip(
+    extra_index_urls=[], packages=[PYTHON_PACKAGE]
+)
+
 
 CONDA_BODY = {"channels": ["conda-forge"], "packages": [PYTHON_PACKAGE_BODY]}
 CONDA = Conda(channels=["conda-forge"], packages=[PYTHON_PACKAGE])
@@ -278,9 +283,16 @@ def test_python_package_schema_dump(object, expected):
     assert data == expected
 
 
-def test_pip_schema_load():
-    data = _PipSchema().load(PIP_BODY)
-    assert data == PIP
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        (PIP_BODY, PIP),
+        (PIP_BODY_WITHOUT_EXTRA_INDEX_URLS, PIP_WITHOUT_EXTRA_INDEX_URLS),
+    ],
+)
+def test_pip_schema_load(body, expected):
+    data = _PipSchema().load(body)
+    assert data == expected
 
 
 def test_pip_schema_dump():

--- a/tests/clients/test_environment.py
+++ b/tests/clients/test_environment.py
@@ -94,6 +94,9 @@ PIP_WITHOUT_EXTRA_INDEX_URLS = Pip(
 CONDA_BODY = {"channels": ["conda-forge"], "packages": [PYTHON_PACKAGE_BODY]}
 CONDA = Conda(channels=["conda-forge"], packages=[PYTHON_PACKAGE])
 
+CONDA_BODY_WITHOUT_CHANNELS = {"packages": [PYTHON_PACKAGE_BODY]}
+CONDA_WITHOUT_CHANNELS = Conda(channels=[], packages=[PYTHON_PACKAGE])
+
 PYTHON_ENVIRONMENT_BODY = {"pip": PIP_BODY, "conda": CONDA_BODY}
 PYTHON_ENVIRONMENT = PythonEnvironment(conda=CONDA, pip=PIP)
 
@@ -300,9 +303,16 @@ def test_pip_schema_dump():
     assert data == PIP_BODY
 
 
-def test_conda_schema_load():
-    data = _CondaSchema().load(CONDA_BODY)
-    assert data == CONDA
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        (CONDA_BODY, CONDA),
+        (CONDA_BODY_WITHOUT_CHANNELS, CONDA_WITHOUT_CHANNELS),
+    ],
+)
+def test_conda_schema_load(body, expected):
+    data = _CondaSchema().load(body)
+    assert data == expected
 
 
 def test_conda_schema_dump():


### PR DESCRIPTION
Currently, it's possible to create an environment specification with no `extra_index_urls` field in the pip packages or no `channels` field in the conda packages, as these fields being `null` is allowed by the backend and marshmallow does not validate that they are set on creation of the environment. Such an environment will then fail on read when marshmallow does finally validate it.

Since these fields being unset is supported by the backend, this PR changes the schema to interpret these fields being unset as "empty list".