### PR TITLE
Support setting spot price with Klostermann

### DIFF
--- a/faculty/clients/cluster.py
+++ b/faculty/clients/cluster.py
@@ -17,28 +17,56 @@ Manage the Faculty cluster configuration.
 """
 
 
-from collections import namedtuple
-
+from attr import attrs, attrib
 from marshmallow import fields, post_load
 
 from faculty.clients.base import BaseSchema, BaseClient
 
 
-NodeType = namedtuple(
-    "NodeType",
-    [
-        "id",
-        "name",
-        "instance_group",
-        "max_interactive_instances",
-        "max_job_instances",
-        "milli_cpus",
-        "memory_mb",
-        "num_gpus",
-        "gpu_name",
-        "cost_usd_per_hour",
-    ],
-)
+@attrs
+class NodeType(object):
+    """A single tenanted node type in the platform.
+
+    Parameters
+    ----------
+    id : str
+        A unique identifier for the node type, usually the cloud provider's
+        machine type.
+    name : str
+        A short descriptive name for the node type, usually the same as the id.
+    instance_group : str
+        The Kubernetes instance group that provides this node type.
+    max_interactive_instances : int
+        The maximum number of instances of this node type that can be used for
+        workspace servers, apps and APIs at any given time.
+    max_job_instances : int
+        The maximum number of instances of this node type that can be used for
+        jobs at any given time.
+    milli_cpus : int
+        The amount of CPU resource available to servers running on nodes of
+        this type.
+    memory_mb : int
+        The amount of memory available to servers running on nodes of this
+        type.
+    num_gpus : int
+        The number of GPUs available to servers running on nodes of this type.
+    gpu_name : str, optional
+        A descriptive name of the type of GPUs available on this node type,
+        when available.
+    cost_usd_per_hour : decimal.Decimal
+        The on-demand hourly cost for this node type, in USD.
+    """
+
+    id = attrib()
+    name = attrib()
+    instance_group = attrib()
+    max_interactive_instances = attrib()
+    max_job_instances = attrib()
+    milli_cpus = attrib()
+    memory_mb = attrib()
+    num_gpus = attrib()
+    gpu_name = attrib()
+    cost_usd_per_hour = attrib()
 
 
 class ClusterClient(BaseClient):

--- a/faculty/clients/cluster.py
+++ b/faculty/clients/cluster.py
@@ -103,6 +103,7 @@ class ClusterClient(BaseClient):
         instance_group,
         max_interactive_instances,
         max_job_instances,
+        spot_max_usd_per_hour=None,
     ):
         """Configure a single tenanted node type on the cluster.
 
@@ -125,12 +126,20 @@ class ClusterClient(BaseClient):
         max_job_instances : int
             The maximum number of jobs runs using this node type to allow to
             run simultaneously.
+        spot_max_usd_per_hour : decimal.Decimal, optional
+            The bid price in USD, when this instance group is configured to run
+            on spot instances.
         """
         payload = {
             "name": name,
             "instanceGroup": instance_group,
             "maxInteractiveInstances": max_interactive_instances,
             "maxJobInstances": max_job_instances,
+            "spotMaxUsdPerHour": (
+                None
+                if spot_max_usd_per_hour is None
+                else str(spot_max_usd_per_hour)
+            ),
         }
         self._put_raw(
             "/node-type/single-tenanted/{}/configuration".format(node_type_id),

--- a/faculty/clients/cluster.py
+++ b/faculty/clients/cluster.py
@@ -55,6 +55,13 @@ class NodeType(object):
         when available.
     cost_usd_per_hour : decimal.Decimal
         The on-demand hourly cost for this node type, in USD.
+    spot_max_usd_per_hour : decimal.Decimal, optional
+        The bid price set for this node type, when using spot instances. The
+        actual cost will usually be lower than this, but the bid price sets the
+        maximum cost (if the spot price increases beyond this price, AWS will
+        shut the instances down). If unset, indicates that the node type is
+        configured to run with on demand instances, and the `cost_usd_per_hour`
+        will be charged.
     """
 
     id = attrib()
@@ -67,6 +74,7 @@ class NodeType(object):
     num_gpus = attrib()
     gpu_name = attrib()
     cost_usd_per_hour = attrib()
+    spot_max_usd_per_hour = attrib()
 
 
 class ClusterClient(BaseClient):
@@ -205,6 +213,9 @@ class _NodeTypeSchema(BaseSchema):
     gpu_name = fields.String(data_key="gpuName", missing=None)
     cost_usd_per_hour = fields.Decimal(
         data_key="costUsdPerHour", required=True
+    )
+    spot_max_usd_per_hour = fields.Decimal(
+        data_key="spotMaxUsdPerHour", missing=None
     )
 
     @post_load

--- a/tests/clients/test_cluster.py
+++ b/tests/clients/test_cluster.py
@@ -32,6 +32,7 @@ NODE_TYPE = NodeType(
     num_gpus=0,
     gpu_name=None,
     cost_usd_per_hour=Decimal("4.2"),
+    spot_max_usd_per_hour=Decimal("2.1"),
 )
 
 NODE_TYPE_BODY = {
@@ -45,6 +46,7 @@ NODE_TYPE_BODY = {
     "costUsdPerHour": 4.2,
     "maxInteractiveInstances": 10,
     "maxJobInstances": 0,
+    "spotMaxUsdPerHour": 2.1,
 }
 
 NODE_TYPE_DEFAULT = NodeType(
@@ -58,6 +60,7 @@ NODE_TYPE_DEFAULT = NodeType(
     num_gpus=0,
     gpu_name=None,
     cost_usd_per_hour=Decimal("4.2"),
+    spot_max_usd_per_hour=None,
 )
 
 NODE_TYPE_BODY_DEFAULT = {

--- a/tests/clients/test_cluster.py
+++ b/tests/clients/test_cluster.py
@@ -148,7 +148,13 @@ def test_cluster_client_list_single_tenanted_node_types(
     )
 
 
-def test_cluster_client_configure_single_tenanted_node_type(mocker):
+@pytest.mark.parametrize(
+    "spot_max_usd_per_hour, expected_spot_price",
+    [(None, None), (Decimal("1.23"), "1.23")],
+)
+def test_cluster_client_configure_single_tenanted_node_type(
+    mocker, spot_max_usd_per_hour, expected_spot_price
+):
     mocker.patch.object(ClusterClient, "_put_raw")
 
     client = ClusterClient(mocker.Mock())
@@ -158,6 +164,7 @@ def test_cluster_client_configure_single_tenanted_node_type(mocker):
         NODE_TYPE.instance_group,
         NODE_TYPE.max_interactive_instances,
         NODE_TYPE.max_job_instances,
+        spot_max_usd_per_hour,
     )
 
     ClusterClient._put_raw.assert_called_once_with(
@@ -167,6 +174,7 @@ def test_cluster_client_configure_single_tenanted_node_type(mocker):
             "instanceGroup": NODE_TYPE.instance_group,
             "maxInteractiveInstances": NODE_TYPE.max_interactive_instances,
             "maxJobInstances": NODE_TYPE.max_job_instances,
+            "spotMaxUsdPerHour": expected_spot_price,
         },
     )
 


### PR DESCRIPTION
We are currently doing a small piece of work to surface information on spot instances in the platform UI. It's currently possible to configure single tenanted instances to run on spot instances in the platform (with a number of strong caveats), however there is nothing to indicate when you are using spot instances and the price shown is the full on-demand price.

We're therefore adding an additional field to the node type configuration in Klostermann that indicates when the node type is running with spot instances, and that indicates the configured bid price. This change to the cluster client is required as it is used to send the configuration to Klostermann, which will subsequently surface it to the frontend.

