### PR TITLE
job definitions no longer return Conda environments, so do not require them

### DIFF
--- a/faculty/clients/job.py
+++ b/faculty/clients/job.py
@@ -98,7 +98,6 @@ JobDefinition = namedtuple(
         "working_dir",
         "command",
         "image_type",
-        "conda_environment",
         "environment_ids",
         "instance_size_type",
         "instance_size",
@@ -494,9 +493,6 @@ class _JobDefinitionSchema(BaseSchema):
     image_type = EnumField(
         ImageType, by_value=True, data_key="imageType", required=True
     )
-    conda_environment = fields.String(
-        data_key="condaEnvironment", missing=None
-    )
     environment_ids = fields.List(
         fields.String(), data_key="environmentIds", required=True
     )
@@ -509,20 +505,6 @@ class _JobDefinitionSchema(BaseSchema):
     max_runtime_seconds = fields.Integer(
         data_key="maxRuntimeSeconds", required=True
     )
-
-    @validates_schema
-    def validate_conda_environment(self, data, **kwargs):
-        image_is_r = data["image_type"] == ImageType.R
-        image_is_python = data["image_type"] == ImageType.PYTHON
-        conda_environment_set = data["conda_environment"] is not None
-        if image_is_r and conda_environment_set:
-            raise ValidationError(
-                "conda environment must only be set for Python images"
-            )
-        elif image_is_python and not conda_environment_set:
-            raise ValidationError(
-                "conda environment must be set for Python images"
-            )
 
     @validates_schema
     def validate_instance_size(self, data, **kwargs):

--- a/tests/clients/test_job.py
+++ b/tests/clients/test_job.py
@@ -124,7 +124,6 @@ JOB_DEFINITION = JobDefinition(
     working_dir="/project/subdir/",
     command=JOB_COMMAND,
     image_type=ImageType.PYTHON,
-    conda_environment="Python3",
     environment_ids=[str(ENVIRONMENT_ID)],
     instance_size_type="custom",
     instance_size=INSTANCE_SIZE,
@@ -134,7 +133,6 @@ JOB_DEFINITION_BODY = {
     "workingDir": JOB_DEFINITION.working_dir,
     "command": JOB_COMMAND_BODY,
     "imageType": JOB_DEFINITION.image_type.value,
-    "condaEnvironment": JOB_DEFINITION.conda_environment,
     "environmentIds": [str(ENVIRONMENT_ID)],
     "instanceSizeType": JOB_DEFINITION.instance_size_type,
     "instanceSize": INSTANCE_SIZE_BODY,
@@ -144,7 +142,6 @@ JOB_DEFINITION_ALTERNATIVE = JobDefinition(
     working_dir="/project/subdir/",
     command=JOB_COMMAND,
     image_type=ImageType.PYTHON,
-    conda_environment="Python3",
     environment_ids=[str(ENVIRONMENT_ID)],
     instance_size_type="m4.xlarge",
     instance_size=None,
@@ -154,7 +151,6 @@ JOB_DEFINITION_ALTERNATIVE_BODY = {
     "workingDir": JOB_DEFINITION.working_dir,
     "command": JOB_COMMAND_BODY,
     "imageType": JOB_DEFINITION.image_type.value,
-    "condaEnvironment": JOB_DEFINITION.conda_environment,
     "environmentIds": [str(ENVIRONMENT_ID)],
     "instanceSizeType": JOB_DEFINITION_ALTERNATIVE.instance_size_type,
     "instanceSize": None,
@@ -355,20 +351,6 @@ def test_job_definition_schema_invalid_instance_type(
     invalid_body = JOB_DEFINITION_BODY.copy()
     invalid_body["instanceSizeType"] = instance_size_type
     invalid_body["instanceSize"] = instance_size
-    with pytest.raises(ValidationError):
-        _JobDefinitionSchema().load(invalid_body)
-
-
-@pytest.mark.parametrize(
-    "image_type, conda_environment",
-    [(ImageType.PYTHON, None), (ImageType.R, "Python3")],
-)
-def test_job_definition_schema_invalid_image_type(
-    image_type, conda_environment
-):
-    invalid_body = JOB_DEFINITION_BODY.copy()
-    invalid_body["imageType"] = image_type
-    invalid_body["condaEnvironment"] = conda_environment
     with pytest.raises(ValidationError):
         _JobDefinitionSchema().load(invalid_body)
 


### PR DESCRIPTION
This seems to be a divergence between server responses and this library. An example server response for a Python job is as follows:

```
{
    "jobId": "[snip]",
    "meta": {
        "name": "somejob",
        "description": "",
        "authorId": "[snip]",
        "createdAt": "2021-09-28T11:10:36.321Z",
        "lastUpdatedAt": "2021-09-28T11:10:36.321Z",
    },
    "definition": {
        "workingDir": "/project",
        "command": {"name": "", "parameters": []},
        "imageType": "python",
        "instanceSizeType": "custom",
        "instanceSize": {"milliCpus": 1000, "memoryMb": 4000},
        "maxRuntimeSeconds": 3600,
        "environmentIds": [],
    },
    "createdFromProjectTemplate": None,
}
```