### PR TITLE
Optional attrib

### DIFF
--- a/faculty/clients/project.py
+++ b/faculty/clients/project.py
@@ -43,7 +43,7 @@ class Project:
     id = attrib()
     name = attrib()
     owner_id = attrib()
-    archived_at = attrib()
+    archived_at = attrib(default=None)
 
 
 class ProjectClient(BaseClient):

--- a/tests/clients/test_project.py
+++ b/tests/clients/test_project.py
@@ -31,7 +31,6 @@ PROJECT = Project(
     id=uuid.uuid4(),
     name="test-project",
     owner_id=uuid.uuid4(),
-    archived_at=None,
 )
 PROJECT_BODY = {
     "projectId": str(PROJECT.id),


### PR DESCRIPTION
It was changed in #180 which broke direct `Project` creation, that is `0.27.2` if this library.

Noticed because since that version the `faculty-cli` tests are not passing, instead currently throwing an error:

```python
ImportError while loading conftest '/Users/gergely/faculty/faculty-cli/test/conftest.py'.
test/conftest.py:17: in <module>
    from test.fixtures import PROFILE, USER_ID
test/fixtures.py:30: in <module>
    PROJECT = Project(id=uuid.uuid4(), name="test-project", owner_id=USER_ID)
E   TypeError: __init__() missing 1 required positional argument: 'archived_at'
ERROR: InvocationError for command /Users/gergely/faculty/faculty-cli/.tox/py38/bin/pytest --cov=faculty_cli (exited with code 4)
```

Testing it locally with:

```shell
python -c "import uuid; from faculty.clients.project import Project; Project(id=uuid.uuid4(), name='test-project', owner_id=uuid.uuid4())"
```

**NB:** need #200 for linting to correctly pass here.

Also this should be a short term / temporary change, and extra work stemming from #197 (followed up in #199) should fix this differently over the long run. The test change within this PR should protect against future issue like this.