### PR TITLE
marshmallow schema maintenance to address RemovedInMarshmallow4Warning results

### DIFF
--- a/faculty/clients/base.py
+++ b/faculty/clients/base.py
@@ -363,8 +363,8 @@ class BaseSchema(Schema):
 
 
 class _ErrorSchema(BaseSchema):
-    error = fields.String(missing=None)
-    error_code = fields.String(data_key="errorCode", missing=None)
+    error = fields.String(load_default=None)
+    error_code = fields.String(data_key="errorCode", load_default=None)
 
 
 def _check_status(response):

--- a/faculty/clients/cluster.py
+++ b/faculty/clients/cluster.py
@@ -201,8 +201,8 @@ class ClusterClient(BaseClient):
 class _NodeTypeSchema(BaseSchema):
 
     id = fields.String(data_key="nodeTypeId", required=True)
-    name = fields.String(missing=None)
-    instance_group = fields.String(data_key="instanceGroup", missing=None)
+    name = fields.String(load_default=None)
+    instance_group = fields.String(data_key="instanceGroup", load_default=None)
     max_interactive_instances = fields.Integer(
         data_key="maxInteractiveInstances", required=True
     )
@@ -212,12 +212,12 @@ class _NodeTypeSchema(BaseSchema):
     milli_cpus = fields.Integer(data_key="milliCpus", required=True)
     memory_mb = fields.Integer(data_key="memoryMb", required=True)
     num_gpus = fields.Integer(data_key="numGpus", required=True)
-    gpu_name = fields.String(data_key="gpuName", missing=None)
+    gpu_name = fields.String(data_key="gpuName", load_default=None)
     cost_usd_per_hour = fields.Decimal(
         data_key="costUsdPerHour", required=True
     )
     spot_max_usd_per_hour = fields.Decimal(
-        data_key="spotMaxUsdPerHour", missing=None
+        data_key="spotMaxUsdPerHour", load_default=None
     )
 
     @post_load

--- a/faculty/clients/environment.py
+++ b/faculty/clients/environment.py
@@ -286,7 +286,7 @@ class _PipSchema(BaseSchema):
     extra_index_urls = fields.List(
         fields.String(),
         data_key="extraIndexUrls",
-        missing=list,
+        load_default=list,
     )
     packages = fields.List(
         fields.Nested(_PythonPackageSchema()), required=True
@@ -298,7 +298,7 @@ class _PipSchema(BaseSchema):
 
 
 class _CondaSchema(BaseSchema):
-    channels = fields.List(fields.String(), missing=list)
+    channels = fields.List(fields.String(), load_default=list)
     packages = fields.List(
         fields.Nested(_PythonPackageSchema()), required=True
     )
@@ -319,10 +319,10 @@ class _PythonEnvironmentSchema(BaseSchema):
 
 class _PythonSpecificationSchema(BaseSchema):
     python2 = fields.Nested(
-        _PythonEnvironmentSchema(), data_key="Python2", missing=None
+        _PythonEnvironmentSchema(), data_key="Python2", load_default=None
     )
     python3 = fields.Nested(
-        _PythonEnvironmentSchema(), data_key="Python3", missing=None
+        _PythonEnvironmentSchema(), data_key="Python3", load_default=None
     )
 
     @post_load
@@ -369,7 +369,7 @@ class _EnvironmentSchema(BaseSchema):
     id = fields.UUID(data_key="environmentId", required=True)
     project_id = fields.UUID(data_key="projectId", required=True)
     name = fields.String(required=True)
-    description = fields.String(missing=None)
+    description = fields.String(load_default=None)
     author_id = fields.UUID(data_key="authorId", required=True)
     created_at = fields.DateTime(data_key="createdAt", required=True)
     updated_at = fields.DateTime(data_key="updatedAt", required=True)
@@ -382,7 +382,7 @@ class _EnvironmentSchema(BaseSchema):
 
 class _EnvironmentCreateUpdateSchema(BaseSchema):
     name = fields.String(required=True)
-    description = fields.String(missing=None)
+    description = fields.String(load_default=None)
     specification = fields.Nested(_SpecificationSchema(), required=True)
 
     @post_load

--- a/faculty/clients/experiment.py
+++ b/faculty/clients/experiment.py
@@ -762,8 +762,8 @@ class _PageSchema(BaseSchema):
 class _PaginationSchema(BaseSchema):
     start = fields.Integer(required=True)
     size = fields.Integer(required=True)
-    previous = fields.Nested(_PageSchema, missing=None)
-    next = fields.Nested(_PageSchema, missing=None)
+    previous = fields.Nested(_PageSchema, load_default=None)
+    next = fields.Nested(_PageSchema, load_default=None)
 
     @post_load
     def make_pagination(self, data, **kwargs):
@@ -808,7 +808,7 @@ class _ExperimentSchema(BaseSchema):
     )
     created_at = fields.DateTime(data_key="createdAt", required=True)
     last_updated_at = fields.DateTime(data_key="lastUpdatedAt", required=True)
-    deleted_at = fields.DateTime(data_key="deletedAt", missing=None)
+    deleted_at = fields.DateTime(data_key="deletedAt", load_default=None)
 
     @post_load
     def make_experiment(self, data, **kwargs):
@@ -820,14 +820,14 @@ class _ExperimentRunSchema(BaseSchema):
     run_number = fields.Integer(data_key="runNumber", required=True)
     experiment_id = fields.Integer(data_key="experimentId", required=True)
     name = fields.String(required=True)
-    parent_run_id = fields.UUID(data_key="parentRunId", missing=None)
+    parent_run_id = fields.UUID(data_key="parentRunId", load_default=None)
     artifact_location = fields.String(
         data_key="artifactLocation", required=True
     )
     status = EnumField(ExperimentRunStatus, by_value=True, required=True)
     started_at = fields.DateTime(data_key="startedAt", required=True)
-    ended_at = fields.DateTime(data_key="endedAt", missing=None)
-    deleted_at = fields.DateTime(data_key="deletedAt", missing=None)
+    ended_at = fields.DateTime(data_key="endedAt", load_default=None)
+    deleted_at = fields.DateTime(data_key="deletedAt", load_default=None)
     tags = fields.Nested(_TagSchema, many=True, required=True)
     params = fields.Nested(_ParamSchema, many=True, required=True)
     metrics = fields.Nested(_MetricSchema, many=True, required=True)
@@ -848,7 +848,7 @@ class _ExperimentRunDataSchema(BaseSchema):
 
 class _ExperimentRunInfoSchema(BaseSchema):
     status = EnumField(ExperimentRunStatus, by_value=True, required=True)
-    ended_at = fields.DateTime(data_key="endedAt", missing=None)
+    ended_at = fields.DateTime(data_key="endedAt", load_default=None)
 
 
 class _ListExperimentRunsResponseSchema(BaseSchema):
@@ -881,7 +881,7 @@ class _ParamFilterValueField(fields.Field):
         elif isinstance(value, int) or isinstance(value, float):
             field = fields.Number()
         else:
-            self.fail("unsupported_type")
+            self.make_error("unsupported_type")
         return field._serialize(value, attr, obj, **kwargs)
 
 
@@ -1055,7 +1055,7 @@ class _SortSchema(_OneOfSchemaWithoutType):
 class _RunQuerySchema(BaseSchema):
     filter = _OptionalField(fields.Nested(_FilterSchema))
     sort = fields.List(fields.Nested(_SortSchema))
-    page = fields.Nested(_PageSchema, missing=None)
+    page = fields.Nested(_PageSchema, load_default=None)
 
 
 # Schemas for responses returned from API:

--- a/faculty/clients/job.py
+++ b/faculty/clients/job.py
@@ -788,7 +788,7 @@ class _JobDefinitionSchema(BaseSchema):
         data_key="instanceSizeType", required=True
     )
     instance_size = fields.Nested(
-        _InstanceSizeSchema, data_key="instanceSize", missing=None
+        _InstanceSizeSchema, data_key="instanceSize", load_default=None
     )
     max_runtime_seconds = fields.Integer(
         data_key="maxRuntimeSeconds", required=True
@@ -840,8 +840,8 @@ class _EnvironmentStepExecutionSchema(BaseSchema):
     state = EnumField(
         EnvironmentStepExecutionState, by_value=True, required=True
     )
-    started_at = fields.DateTime(data_key="startedAt", missing=None)
-    ended_at = fields.DateTime(data_key="endedAt", missing=None)
+    started_at = fields.DateTime(data_key="startedAt", load_default=None)
+    ended_at = fields.DateTime(data_key="endedAt", load_default=None)
 
     @post_load
     def make_environment_step_execution(self, data, **kwargs):
@@ -852,8 +852,8 @@ class _SubrunSummarySchema(BaseSchema):
     id = fields.UUID(data_key="subrunId", required=True)
     subrun_number = fields.Integer(data_key="subrunNumber", required=True)
     state = EnumField(SubrunState, by_value=True, required=True)
-    started_at = fields.DateTime(data_key="startedAt", missing=None)
-    ended_at = fields.DateTime(data_key="endedAt", missing=None)
+    started_at = fields.DateTime(data_key="startedAt", load_default=None)
+    ended_at = fields.DateTime(data_key="endedAt", load_default=None)
 
     @post_load
     def make_subrun_summary(self, data, **kwargs):
@@ -864,8 +864,8 @@ class _SubrunSchema(BaseSchema):
     id = fields.UUID(data_key="subrunId", required=True)
     subrun_number = fields.Integer(data_key="subrunNumber", required=True)
     state = EnumField(SubrunState, by_value=True, required=True)
-    started_at = fields.DateTime(data_key="startedAt", missing=None)
-    ended_at = fields.DateTime(data_key="endedAt", missing=None)
+    started_at = fields.DateTime(data_key="startedAt", load_default=None)
+    ended_at = fields.DateTime(data_key="endedAt", load_default=None)
     environment_step_executions = fields.Nested(
         _EnvironmentStepExecutionSchema,
         data_key="environmentExecutionState",
@@ -883,8 +883,8 @@ class _RunSummarySchema(BaseSchema):
     run_number = fields.Integer(data_key="runNumber", required=True)
     state = EnumField(RunState, by_value=True, required=True)
     submitted_at = fields.DateTime(data_key="submittedAt", required=True)
-    started_at = fields.DateTime(data_key="startedAt", missing=None)
-    ended_at = fields.DateTime(data_key="endedAt", missing=None)
+    started_at = fields.DateTime(data_key="startedAt", load_default=None)
+    ended_at = fields.DateTime(data_key="endedAt", load_default=None)
 
     @post_load
     def make_run_summary(self, data, **kwargs):
@@ -896,8 +896,8 @@ class _RunSchema(BaseSchema):
     run_number = fields.Integer(data_key="runNumber", required=True)
     state = EnumField(RunState, by_value=True, required=True)
     submitted_at = fields.DateTime(data_key="submittedAt", required=True)
-    started_at = fields.DateTime(data_key="startedAt", missing=None)
-    ended_at = fields.DateTime(data_key="endedAt", missing=None)
+    started_at = fields.DateTime(data_key="startedAt", load_default=None)
+    ended_at = fields.DateTime(data_key="endedAt", load_default=None)
     subruns = fields.Nested(_SubrunSummarySchema, many=True, required=True)
 
     @post_load
@@ -925,8 +925,8 @@ class _PageSchema(BaseSchema):
 class _PaginationSchema(BaseSchema):
     start = fields.Integer(required=True)
     size = fields.Integer(required=True)
-    previous = fields.Nested(_PageSchema, missing=None)
-    next = fields.Nested(_PageSchema, missing=None)
+    previous = fields.Nested(_PageSchema, load_default=None)
+    next = fields.Nested(_PageSchema, load_default=None)
 
     @post_load
     def make_pagination(self, data, **kwargs):

--- a/faculty/clients/model.py
+++ b/faculty/clients/model.py
@@ -220,7 +220,7 @@ class _ModelSchema(BaseSchema):
     description = fields.String(required=True)
     user_ids = fields.List(fields.UUID, data_key="users", required=True)
     latest_version = fields.Nested(
-        _ModelVersionSchema, data_key="latestVersion", missing=None
+        _ModelVersionSchema, data_key="latestVersion", load_default=None
     )
 
     @post_load

--- a/faculty/clients/object.py
+++ b/faculty/clients/object.py
@@ -439,7 +439,9 @@ class _ObjectSchema(BaseSchema):
 
 class _ListObjectsResponseSchema(BaseSchema):
     objects = fields.List(fields.Nested(_ObjectSchema), required=True)
-    next_page_token = fields.String(data_key="nextPageToken", missing=None)
+    next_page_token = fields.String(
+        data_key="nextPageToken", load_default=None
+    )
 
     @post_load
     def make_list_objects_response(self, data, **kwargs):
@@ -456,8 +458,8 @@ class _SimplePresignResponseSchema(BaseSchema):
 
 class _PresignUploadResponseSchema(BaseSchema):
     provider = EnumField(CloudStorageProvider, by_value=True, required=True)
-    upload_id = fields.String(data_key="uploadId", missing=None)
-    url = fields.String(missing=None)
+    upload_id = fields.String(data_key="uploadId", load_default=None)
+    url = fields.String(load_default=None)
 
     @post_load
     def make_presign_upload_response(self, data, **kwargs):

--- a/faculty/clients/project.py
+++ b/faculty/clients/project.py
@@ -161,7 +161,7 @@ class _ProjectSchema(BaseSchema):
     id = fields.UUID(data_key="projectId", required=True)
     name = fields.Str(required=True)
     owner_id = fields.UUID(data_key="ownerId", required=True)
-    archived_at = fields.DateTime(data_key="archivedAt", missing=None)
+    archived_at = fields.DateTime(data_key="archivedAt", load_default=None)
 
     @post_load
     def make_project(self, data, **kwargs):

--- a/faculty/clients/serveragent.py
+++ b/faculty/clients/serveragent.py
@@ -273,8 +273,8 @@ class _EnvironmentExecutionStepSchema(BaseSchema):
     status = EnumField(
         EnvironmentExecutionStepStatus, by_value=True, required=True
     )
-    started_at = fields.DateTime(data_key="startedAt", missing=None)
-    finished_at = fields.DateTime(data_key="finishedAt", missing=None)
+    started_at = fields.DateTime(data_key="startedAt", load_default=None)
+    finished_at = fields.DateTime(data_key="finishedAt", load_default=None)
 
     @post_load
     def make_environment_execution_step(self, data, **kwargs):
@@ -296,8 +296,8 @@ class _ExecutionSchema(BaseSchema):
     id = fields.UUID(data_key="executionId", required=True)
     status = EnumField(ExecutionStatus, by_value=True, required=True)
     environments = fields.List(fields.Nested(_EnvironmentExecutionSchema))
-    started_at = fields.DateTime(data_key="startedAt", missing=None)
-    finished_at = fields.DateTime(data_key="finishedAt", missing=None)
+    started_at = fields.DateTime(data_key="startedAt", load_default=None)
+    finished_at = fields.DateTime(data_key="finishedAt", load_default=None)
 
     @post_load
     def make_execution(self, data, **kwargs):

--- a/faculty/clients/user.py
+++ b/faculty/clients/user.py
@@ -133,14 +133,14 @@ class _UserSchema(BaseSchema):
 
     id = fields.UUID(data_key="userId", required=True)
     username = fields.Str(required=True)
-    full_name = fields.Str(data_key="fullName", missing=None)
+    full_name = fields.Str(data_key="fullName", load_default=None)
     email = fields.Str(required=True)
     created_at = fields.DateTime(data_key="createdAt", required=True)
     enabled = fields.Boolean(required=True)
     global_roles = fields.List(
         EnumField(GlobalRole, by_value=True),
         data_key="globalRoles",
-        missing=None,
+        load_default=None,
     )
     is_system = fields.Boolean(data_key="isSystem", required=True)
 

--- a/faculty/clients/workspace.py
+++ b/faculty/clients/workspace.py
@@ -90,7 +90,7 @@ class _FileNodeSchema(BaseSchema):
     last_modified = fields.DateTime(required=True)
     size = fields.Integer(required=True)
     truncated = fields.Boolean()
-    content = fields.Nested("self", many=True)
+    content = fields.Nested(lambda: _FileNodeSchema, many=True)
 
     @validates_schema
     def validate_type(self, data, **kwargs):


### PR DESCRIPTION
Since the dependency list do not limit the `marshmallow` version, it is likely prudent to fix the multitude of `RemovedInMarshmallow4Warning` results that the tests are throwing. Most of them are pretty straightforward, but happy to elaborate.

Tests were run with `tox -e py38 -- -Werror` to make warnings into errors for the process.

There's one remaining warning that is coming from the `marshmallow_enum` library, and #202 should be relevant for this.